### PR TITLE
tec: Add a command to get an overview of the app files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ lint: ## Execute the linter (PHPStan and PHP_CodeSniffer)
 lint-fix: ## Fix the errors detected by the linters (PHP_CodeSniffer)
 	$(PHP) vendor/bin/phpcbf
 
+.PHONY: tree
+tree:  ## Display the structure of the application
+	tree -I 'vendor|var|coverage' --dirsfirst -CA
+
 .PHONY: help
 help:
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a `tree` command to the Makefile

How to test the feature manually:

1. Execute `make tree`

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
