### PR TITLE
fix: Rename user_id_seq sequence in users_id_seq

### DIFF
--- a/migrations/Version20220930143409RenameUserInUsers.php
+++ b/migrations/Version20220930143409RenameUserInUsers.php
@@ -19,6 +19,7 @@ final class Version20220930143409RenameUserInUsers extends AbstractMigration
         $dbPlatform = $this->connection->getDatabasePlatform()->getName();
         if ($dbPlatform === 'postgresql') {
             $this->addSql('ALTER TABLE "user" RENAME TO "users"');
+            $this->addSql('ALTER SEQUENCE "user_id_seq" RENAME TO "users_id_seq"');
         } elseif ($dbPlatform === 'mysql') {
             $this->addSql('ALTER TABLE `user` RENAME TO `users`');
         }
@@ -29,6 +30,7 @@ final class Version20220930143409RenameUserInUsers extends AbstractMigration
         $dbPlatform = $this->connection->getDatabasePlatform()->getName();
         if ($dbPlatform === 'postgresql') {
             $this->addSql('ALTER TABLE "users" RENAME TO "user"');
+            $this->addSql('ALTER SEQUENCE "users_id_seq" RENAME TO "user_id_seq"');
         } elseif ($dbPlatform === 'mysql') {
             $this->addSql('ALTER TABLE `users` RENAME TO `user`');
         }


### PR DESCRIPTION
Related to 74ca91ad1cc08ce7c205554733ef34b7e3e9a20a

Changes proposed in this pull request:

- Rename user_id_seq sequence in users_id_seq

How to test the feature manually:

1. reset the database
2. create a user
3. check it works

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
