### PR TITLE
imp: Move the logout button to the layout header

### DIFF
--- a/assets/stylesheets/components/layout.css
+++ b/assets/stylesheets/components/layout.css
@@ -2,13 +2,25 @@
 /* Copyright 2022 Probesys */
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
 
-.layout__header {
-    text-align: center;
+.layout__header-container {
+    display: flex;
+    max-width: 1200px;
+    margin-right: auto;
+    margin-left: auto;
+
+    align-items: center;
+    justify-content: center;
+}
+
+.layout__header-container > * {
+    padding-right: 1.5rem;
+    padding-left: 1.5rem;
 }
 
 .layout__header-home {
     display: inline-block;
-    padding: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
 
     color: inherit;
     font-size: 1.1em;
@@ -16,6 +28,10 @@
     text-decoration: none;
 
     outline-offset: -0.3rem;
+}
+
+.layout__header-extend {
+    flex: 1;
 }
 
 .layout__body {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,10 +23,24 @@
 
     <body>
         <nav class="layout__header">
-            <div class="wrapper-large wrapper--center">
+            <div class="layout__header-container">
                 <a class="layout__header-home" href="{{ path('home') }}">
                     🤝 Bileto
                 </a>
+
+                {% if app.user %}
+                    <div class="layout__header-extend"></div>
+
+                    <form action="{{ path('logout') }}" method="post">
+                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('logout') }}">
+
+                        <div class="form__actions">
+                            <button id="form-logout-submit" type="submit">
+                                {{ 'Logout' | trans }}
+                            </button>
+                        </div>
+                    </form>
+                {% endif %}
             </div>
         </nav>
 

--- a/templates/home/show.html.twig
+++ b/templates/home/show.html.twig
@@ -9,15 +9,5 @@
 {% block body %}
     <main class="layout__body wrapper-small wrapper--center flow">
         <h1>{{ 'Hello Bileto!' | trans }}</h1>
-
-        <form action="{{ path('logout') }}" method="post">
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token('logout') }}">
-
-            <div class="form__actions">
-                <button id="form-logout-submit" type="submit">
-                    {{ 'Logout' | trans }}
-                </button>
-            </div>
-        </form>
     </main>
 {% endblock %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Move the logout button to the layout header
- Adapt the design of the layout header to accept navigation items

How to test the feature manually:

1. log in to the application
2. check that the header contains a logout button
3. check it looks good on mobile

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
