### PR TITLE
tec: Fix initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 /.env.*.local
 /config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
-/public/assets/
+/public/assets/*
+!/public/assets/.keep
 /public/manifest.json
 /var/
 /vendor/

--- a/.vite/empty-assets-dir-plugin.js
+++ b/.vite/empty-assets-dir-plugin.js
@@ -21,6 +21,10 @@ export default function emptyAssetsDirPlugin () {
                 if (err) throw err;
 
                 for (const filename of filenames) {
+                    if (filename === '.keep') {
+                        continue;
+                    }
+
                     fs.unlink(path.join(assetsFullDir, filename), (err) => {
                         if (err) throw err;
                     });

--- a/README.md
+++ b/README.md
@@ -50,19 +50,25 @@ Install the dependencies:
 $ make install
 ```
 
-Setup the database:
-
-```console
-$ make db-setup
-```
-
 Start the development server:
 
 ```console
 $ make docker-start
 ```
 
-And open [localhost:8000](http://localhost:8000).
+Setup the database:
+
+```console
+$ make db-setup
+```
+
+Create a user:
+
+```console
+$ ./docker/bin/console app:users:create --email=alix@example.com --password=secret
+```
+
+Open [localhost:8000](http://localhost:8000) and login with your user credentials.
 
 A note about the `make` commands: they might feel magic, but they are not!
 They are just shortcuts for common commands.


### PR DESCRIPTION
Changes proposed in this pull request:

- Keep track of the `public/assets/` folder
- Improve development setup documentation
    - Invert `make docker-start` and `make db-setup` commands
    - Indicate how to create a user

How to test the feature manually:

1. Setup a new environment
2. Follow the instructions from the README
3. Check the instructions work

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
