### PR TITLE
imp: Add colours to status and priority badges

### DIFF
--- a/assets/stylesheets/_colors.dark.css
+++ b/assets/stylesheets/_colors.dark.css
@@ -44,6 +44,19 @@
     --color-grey11: #9ba1a6;
     --color-grey12: #ecedee;
 
+    --color-info1: #0c1820;
+    --color-info2: #071d2a;
+    --color-info3: #082636;
+    --color-info4: #082d41;
+    --color-info5: #08354c;
+    --color-info6: #083e59;
+    --color-info7: #064b6b;
+    --color-info8: #005d85;
+    --color-info9: #68ddfd;
+    --color-info10: #8ae8ff;
+    --color-info11: #2ec8ee;
+    --color-info12: #eaf8ff;
+
     --color-primary1: #0f1720;
     --color-primary2: #0f1b2d;
     --color-primary3: #10243e;
@@ -69,6 +82,19 @@
     --color-success10: #3cb179;
     --color-success11: #4cc38a;
     --color-success12: #e5fbeb;
+
+    --color-warning1: #1f1300;
+    --color-warning2: #271700;
+    --color-warning3: #341c00;
+    --color-warning4: #3f2200;
+    --color-warning5: #4a2900;
+    --color-warning6: #573300;
+    --color-warning7: #693f05;
+    --color-warning8: #824e00;
+    --color-warning9: #ffb224;
+    --color-warning10: #ffcb47;
+    --color-warning11: #f1a10d;
+    --color-warning12: #fef3dd;
 
     --color-box-shadow: rgb(0 0 0 / 50%);
 }

--- a/assets/stylesheets/_colors.light.css
+++ b/assets/stylesheets/_colors.light.css
@@ -44,6 +44,19 @@
     --color-grey11: #687076;
     --color-grey12: #11181c;
 
+    --color-info1: #f9feff;
+    --color-info2: #f1fcff;
+    --color-info3: #e4f9ff;
+    --color-info4: #d5f4fd;
+    --color-info5: #c1ecf9;
+    --color-info6: #a4dff1;
+    --color-info7: #79cfea;
+    --color-info8: #2ebde5;
+    --color-info9: #68ddfd;
+    --color-info10: #5fd4f4;
+    --color-info11: #0078a1;
+    --color-info12: #003242;
+
     --color-primary1: #fbfdff;
     --color-primary2: #f5faff;
     --color-primary3: #edf6ff;
@@ -69,6 +82,19 @@
     --color-success10: #299764;
     --color-success11: #18794e;
     --color-success12: #153226;
+
+    --color-warning1: #fefdfb;
+    --color-warning2: #fff9ed;
+    --color-warning3: #fff4d5;
+    --color-warning4: #ffecbc;
+    --color-warning5: #ffe3a2;
+    --color-warning6: #ffd386;
+    --color-warning7: #f3ba63;
+    --color-warning8: #ee9d2b;
+    --color-warning9: #ffb224;
+    --color-warning10: #ffa01c;
+    --color-warning11: #ad5700;
+    --color-warning12: #4e2009;
 
     --color-box-shadow: rgb(0 0 0 / 12%);
 }

--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -9,6 +9,7 @@
 @import "./utils/wrapper.css";
 @import "./components/alerts.css";
 @import "./components/anchors.css";
+@import "./components/badges.css";
 @import "./components/buttons.css";
 @import "./components/cards.css";
 @import "./components/forms.css";

--- a/assets/stylesheets/components/badges.css
+++ b/assets/stylesheets/components/badges.css
@@ -1,0 +1,45 @@
+/* This file is part of Bileto. */
+/* Copyright 2022 Probesys */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+
+.badge {
+    padding: 0.75rem 1.5rem;
+
+    text-align: center;
+
+    border-radius: 2.5rem;
+}
+
+.badge--bold {
+    font-weight: bold;
+}
+
+.badge--blue {
+    color: var(--color-info12);
+
+    background-color: var(--color-info5);
+}
+
+.badge--green {
+    color: var(--color-success12);
+
+    background-color: var(--color-success5);
+}
+
+.badge--grey {
+    color: var(--color-grey12);
+
+    background-color: var(--color-grey5);
+}
+
+.badge--orange {
+    color: var(--color-warning12);
+
+    background-color: var(--color-warning5);
+}
+
+.badge--red {
+    color: var(--color-error12);
+
+    background-color: var(--color-error5);
+}

--- a/assets/stylesheets/pages/tickets-show.css
+++ b/assets/stylesheets/pages/tickets-show.css
@@ -25,24 +25,19 @@
     }
 }
 
+.tickets-show .ticket__status {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+@media (min-width: 800px) {
+    .tickets-show .ticket__status {
+        display: inline-block;
+        margin-right: 0.5rem;
+        margin-bottom: 0;
+    }
+}
+
 .tickets-show .ticket__info {
     font-size: 0.9em;
-}
-
-.tickets-show .ticket__status {
-    margin-right: 1rem;
-    padding: 0.75rem 1.5rem;
-
-    background-color: var(--color-grey5);
-    border-radius: 2.5rem;
-}
-
-.tickets-show .ticket__priority {
-    padding: 0.75rem 1.5rem;
-
-    font-weight: bold;
-    text-align: center;
-
-    background-color: var(--color-grey5);
-    border-radius: 0.5rem;
 }

--- a/src/Entity/Ticket.php
+++ b/src/Entity/Ticket.php
@@ -177,6 +177,21 @@ class Ticket
         return $statusesWithLabels[$this->status];
     }
 
+    public function getStatusBadgeColor(): ?string
+    {
+        if (
+            $this->status === 'new' ||
+            $this->status === 'assigned' ||
+            $this->status === 'in_progress'
+        ) {
+            return 'green';
+        } elseif ($this->status === 'pending') {
+            return 'blue';
+        } else {
+            return 'grey';
+        }
+    }
+
     public function setStatus(string $status): self
     {
         $this->status = $status;
@@ -241,6 +256,19 @@ class Ticket
     {
         $weightsWithLabels = self::getWeightsWithLabels();
         return $weightsWithLabels[$this->priority];
+    }
+
+    public function getPriorityBadgeColor(): ?string
+    {
+        if ($this->priority === 'low') {
+            return 'blue';
+        } elseif ($this->priority === 'medium') {
+            return 'orange';
+        } elseif ($this->priority === 'high') {
+            return 'red';
+        } else {
+            return 'grey';
+        }
     }
 
     public function setPriority(string $priority): self

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -100,12 +100,16 @@
                                         {% endif %}
                                     </td>
 
-                                    <td>
-                                        {{ ticket.statusLabel | trans }}
+                                    <td class="text--center">
+                                        <span class="badge badge--{{ ticket.statusBadgeColor }}">
+                                            {{ ticket.statusLabel | trans }}
+                                        </span>
                                     </td>
 
-                                    <td>
-                                        {{ ticket.priorityLabel | trans }}
+                                    <td class="text--center">
+                                        <span class="badge badge--{{ ticket.priorityBadgeColor }}">
+                                            {{ ticket.priorityLabel | trans }}
+                                        </span>
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -27,7 +27,7 @@
             </div>
 
             <div class="text--center">
-                <span class="ticket__status ticket__status--{{ ticket.status }}" title="{{ 'Status' | trans }}">{{ icon('status') }} {{ ticket.statusLabel | trans }}</span>
+                <span class="ticket__status badge badge--bold badge--{{ ticket.statusBadgeColor }}" title="{{ 'Status' | trans }}">{{ icon('status') }} {{ ticket.statusLabel | trans }}</span>
 
                 <span class="text--small">
                     <strong>{{ ticket.createdBy.email }}</strong>
@@ -233,8 +233,7 @@
                             </span>
                         </button>
                     </div>
-
-                    <div class="ticket__priority">
+                    <div class="ticket__priority badge badge--bold badge--{{ ticket.priorityBadgeColor }}">
                         {{ ticket.priorityLabel | trans }}
                     </div>
 


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/92

Changes proposed in this pull request:

- Add colours for info (blue) and warnings (orange)
- Create a new `.badge` component
- Display status and priority with the badge component and change colours based on values of the properties

How to test the feature manually:

1. Create a ticket
2. Change priority and status
3. Check the colours change

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
