### PR TITLE
imp: Autoselect status based on assignment in new ticket form

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -10,6 +10,7 @@ import FormPriorityController from '@/controllers/form_priority_controller.js';
 import ModalController from '@/controllers/modal_controller.js';
 import ModalOpenerController from '@/controllers/modal_opener_controller.js';
 import PopupController from '@/controllers/popup_controller.js';
+import NewTicketController from '@/controllers/new_ticket_controller.js';
 import TinymceController from '@/controllers/tinymce_controller.js';
 
 const application = Application.start();
@@ -17,6 +18,7 @@ application.register('color-scheme', ColorSchemeController);
 application.register('form-priority', FormPriorityController);
 application.register('modal', ModalController);
 application.register('modal-opener', ModalOpenerController);
+application.register('new-ticket', NewTicketController);
 application.register('popup', PopupController);
 application.register('tinymce', TinymceController);
 

--- a/assets/javascripts/controllers/new_ticket_controller.js
+++ b/assets/javascripts/controllers/new_ticket_controller.js
@@ -1,0 +1,30 @@
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static get targets () {
+        return ['assigneeSelect', 'statusSelect'];
+    }
+
+    updateStatus () {
+        const isAssigned = this.assigneeSelectTarget.value !== '';
+        const status = this.statusSelectTarget.value;
+
+        const newOption = this.statusSelectTarget.querySelector('option[value="new"]');
+
+        if (isAssigned) {
+            newOption.disabled = true;
+            if (status === 'new') {
+                this.statusSelectTarget.value = 'assigned';
+            }
+        } else {
+            newOption.disabled = false;
+            if (status === 'assigned') {
+                this.statusSelectTarget.value = 'new';
+            }
+        }
+    }
+}

--- a/templates/organizations/tickets/new.html.twig
+++ b/templates/organizations/tickets/new.html.twig
@@ -26,6 +26,7 @@
             action="{{ path('create organization ticket', {'uid': organization.uid}) }}"
             method="post"
             class="wrapper wrapper--center flow"
+            data-controller="new-ticket"
         >
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('create organization ticket') }}">
 
@@ -145,6 +146,8 @@
                             aria-invalid="true"
                             aria-errormessage="assignee-error"
                         {% endif %}
+                        data-action="new-ticket#updateStatus"
+                        data-new-ticket-target="assigneeSelect"
                     >
                         <option value="">
                             {{ 'Unassigned' | trans }}
@@ -181,6 +184,7 @@
                         aria-invalid="true"
                         aria-errormessage="status-error"
                     {% endif %}
+                    data-new-ticket-target="statusSelect"
                 >
                     {% for value, label in statuses %}
                         <option value="{{ value }}" {{ value == status ? 'selected' }}>


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/91

Changes proposed in this pull request:

- Create a Stimulus controller to manage the status in the new ticket form
- disable "new" status option if ticket is assigned (and set the "assignee" value)
- enable "new" status option if ticket is not assigned (and set the "new" value)

How to test the feature manually:

1. go to the new ticket form
2. select an assignee, check the status is set to "assigned" (and that the "new" option is disabled)
3. unselect the assignee, check the status is set back to "new"

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
