### PR TITLE
imp: Improve format of dates

### DIFF
--- a/assets/stylesheets/components/messages.css
+++ b/assets/stylesheets/components/messages.css
@@ -90,6 +90,10 @@
     border-radius: 0.5rem 0.5rem 0 0;
 }
 
+.message__top * + * {
+    margin-left: 0.25rem;
+}
+
 .message__top-separator {
     flex: 1;
 }
@@ -100,6 +104,7 @@
 
 .message__date {
     color: var(--color-grey11);
+    font-size: 0.9em;
 }
 
 .message__content {

--- a/src/Service/DateTranslator.php
+++ b/src/Service/DateTranslator.php
@@ -1,0 +1,41 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class DateTranslator
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function format(\DateTimeInterface $date, string $format = 'dd MMM Y, HH:mm'): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $currentLocale = $request->getLocale();
+
+        $formatter = new \IntlDateFormatter(
+            $currentLocale,
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::FULL,
+            null,
+            null,
+            $format
+        );
+
+        $translatedDate = $formatter->format($date);
+        if ($translatedDate === false) {
+            throw new \Exception("Cannot translate the date (format: {$format})");
+        }
+
+        return $translatedDate;
+    }
+}

--- a/src/Twig/DateFormatterExtension.php
+++ b/src/Twig/DateFormatterExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Twig;
+
+use App\Service\DateTranslator;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class DateFormatterExtension extends AbstractExtension
+{
+    private DateTranslator $dateTranslator;
+
+    public function __construct(DateTranslator $dateTranslator)
+    {
+        $this->dateTranslator = $dateTranslator;
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('dateTrans', [$this, 'dateTrans']),
+            new TwigFilter('dateIso', [$this, 'dateIso']),
+        ];
+    }
+
+    public function dateTrans(\DateTimeInterface $date, string $format = 'dd MMM Y, HH:mm'): string
+    {
+        return $this->dateTranslator->format($date, $format);
+    }
+
+    public function dateIso(\DateTimeInterface $date): string
+    {
+        return $date->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -87,7 +87,7 @@
                         <table>
                             <thead>
                                 <tr>
-                                    <th class="col--size2">
+                                    <th class="col--size4">
                                         {{ 'Opened on' | trans }}
                                     </th>
 
@@ -128,7 +128,9 @@
                                 {% for ticket in tickets|sort((a, b) => b.createdAt <=> a.createdAt) %}
                                     <tr data-test="ticket-item">
                                         <td>
-                                            {{ ticket.createdAt.format('Y-m-d') }}
+                                            <time datetime="{{ ticket.createdAt | dateIso }}" class="text--small">
+                                                {{ ticket.createdAt | dateTrans }}
+                                            </time>
                                         </td>
 
                                         <td class="text--right td--anchor">

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -38,7 +38,9 @@
                         {{ 'opened this <strong>incident</strong>' | trans | raw }}
                     {% endif %}
 
-                    {{ 'on %date%' | trans({ '%date%': ticket.createdAt.format('Y-m-d') }) }}
+                    <time datetime="{{ ticket.createdAt | dateIso }}">
+                        {{ 'on %date%' | trans({ '%date%': ticket.createdAt | dateTrans }) }}
+                    </time>
                 </span>
             </div>
         </div>
@@ -75,9 +77,9 @@
 
                                     <div class="message__top-separator"></div>
 
-                                    <div class="message__date">
-                                        {{ message.createdAt.format('Y-m-d') }}
-                                    </div>
+                                    <time datetime="{{ message.createdAt | dateIso }}" class="message__date">
+                                        {{ message.createdAt | dateTrans }}
+                                    </time>
                                 </div>
 
                                 <div class="message__content">


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/76

Changes proposed in this pull request:

- Create a class to translate dates accordingly to the current locale
- Create a Twig extension to use this translator
- Format the dates with the new Twig filters
- Adapt the layout (the strings are longer than before)

How to test the feature manually:

1. Open a ticket
2. Check that dates in the tickets list and on the ticket page are correctly formatted (day month year, hour:minute)
3. Check the dates are in a `<time>` element

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
