### PR TITLE
new: Rename the tickets

### DIFF
--- a/src/Controller/Tickets/TitleController.php
+++ b/src/Controller/Tickets/TitleController.php
@@ -1,0 +1,69 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Controller\Tickets;
+
+use App\Controller\BaseController;
+use App\Entity\Ticket;
+use App\Repository\TicketRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class TitleController extends BaseController
+{
+    #[Route('/tickets/{uid}/title/edit', name: 'edit ticket title', methods: ['GET', 'HEAD'])]
+    public function edit(Ticket $ticket): Response
+    {
+        return $this->render('tickets/title/edit.html.twig', [
+            'ticket' => $ticket,
+            'title' => $ticket->getTitle(),
+        ]);
+    }
+
+    #[Route('/tickets/{uid}/title/edit', name: 'update ticket title', methods: ['POST'])]
+    public function update(
+        Ticket $ticket,
+        Request $request,
+        TicketRepository $ticketRepository,
+        ValidatorInterface $validator,
+    ): Response {
+        $oldTitle = $ticket->getTitle();
+
+        /** @var string $title */
+        $title = $request->request->get('title', $oldTitle);
+
+        /** @var string $csrfToken */
+        $csrfToken = $request->request->get('_csrf_token', '');
+
+        if (!$this->isCsrfTokenValid('update ticket title', $csrfToken)) {
+            return $this->renderBadRequest('tickets/title/edit.html.twig', [
+                'ticket' => $ticket,
+                'title' => $title,
+                'error' => $this->csrfError(),
+            ]);
+        }
+
+        $ticket->setTitle($title);
+
+        $errors = $validator->validate($ticket);
+        if (count($errors) > 0) {
+            $ticket->setTitle($oldTitle);
+            return $this->renderBadRequest('tickets/title/edit.html.twig', [
+                'ticket' => $ticket,
+                'title' => $title,
+                'errors' => $this->formatErrors($errors),
+            ]);
+        }
+
+        $ticketRepository->save($ticket, true);
+
+        return $this->redirectToRoute('ticket', [
+            'uid' => $ticket->getUid(),
+        ]);
+    }
+}

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -241,6 +241,19 @@
                                     </button>
                                 {% endif %}
                             </form>
+
+                            <button
+                                class="popup__item"
+                                type="submit"
+                                role="menuitem"
+                                data-controller="modal-opener"
+                                data-action="modal-opener#fetch"
+                                data-modal-opener-href-value="{{ path('edit ticket title', { uid: ticket.uid }) }}"
+                                aria-haspopup="dialog"
+                                aria-controls="modal"
+                            >
+                                {{ 'Rename the ticket' | trans }}
+                            </button>
                         </nav>
                     </details>
                 </div>

--- a/templates/tickets/title/edit.html.twig
+++ b/templates/tickets/title/edit.html.twig
@@ -1,0 +1,64 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+{% extends 'modal.html.twig' %}
+
+{% block title %}{{ 'Rename the ticket' | trans }}{% endblock %}
+
+{% block body %}
+    <form
+        action="{{ path('update ticket title', {'uid': ticket.uid}) }}"
+        method="post"
+        class="wrapper wrapper--center flow"
+    >
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token('update ticket title') }}">
+
+        {% if error %}
+            <div class="alert alert--error" role="alert" data-turbo-cache="false" data-test="alert-error">
+                <div class="alert__title">{{ 'Error' | trans }}</div>
+
+                <p class="alert__message">
+                    {{ error }}
+                </p>
+            </div>
+        {% endif %}
+
+        <div class="flow-small">
+            <label for="title">
+                {{ 'Title' | trans }}
+                <small class="text--secondary">
+                    {{ '(max. 255 characters)' | trans }}
+                </small>
+            </label>
+
+            {% if errors.title is defined %}
+                <p class="form__error" role="alert" id="title-error">
+                    <span class="sr-only">{{ 'Error' | trans }}</span>
+                    {{ errors.title }}
+                </p>
+            {% endif %}
+
+            <input
+                type="text"
+                id="title"
+                name="title"
+                value="{{ title }}"
+                required
+                maxlength="255"
+                {% if errors.title is defined %}
+                    aria-invalid="true"
+                    aria-errormessage="title-error"
+                {% endif %}
+            />
+        </div>
+
+        <div class="form__actions">
+            <button id="form-update-title-submit" class="button--primary" type="submit">
+                {{ 'Save the changes' | trans }}
+            </button>
+        </div>
+    </form>
+{% endblock %}

--- a/tests/Controller/Tickets/TitleControllerTest.php
+++ b/tests/Controller/Tickets/TitleControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Controller\Tickets;
+
+use App\Factory\TicketFactory;
+use App\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class TitleControllerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testGetEditRendersCorrectly(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+        ]);
+
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Rename the ticket');
+    }
+
+    public function testGetEditRedirectsToLoginIfNotConnected(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+        ]);
+
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+
+        $this->assertResponseRedirects('http://localhost/login', 302);
+    }
+
+    public function testPostUpdateSavesTicketAndRedirects(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $oldTitle = 'My ticket';
+        $newTitle = 'My urgent ticket!';
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+            'title' => $oldTitle,
+        ]);
+
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+        $crawler = $client->submitForm('form-update-title-submit', [
+            'title' => $newTitle,
+        ]);
+
+        $this->assertResponseRedirects("/tickets/{$ticket->getUid()}", 302);
+        $ticket->refresh();
+        $this->assertSame($newTitle, $ticket->getTitle());
+    }
+
+    public function testPostUpdateFailsIfTitleIsInvalid(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $oldTitle = 'My ticket';
+        $newTitle = str_repeat('a', 256);
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+            'title' => $oldTitle,
+        ]);
+
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+        $crawler = $client->submitForm('form-update-title-submit', [
+            'title' => $newTitle,
+        ]);
+
+        $ticket->refresh();
+        $this->assertSelectorTextContains('#title-error', 'The title must be 255 characters maximum.');
+        $this->assertSame($oldTitle, $ticket->getTitle());
+    }
+
+    public function testPostUpdateFailsIfCsrfTokenIsInvalid(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $oldTitle = 'My ticket';
+        $newTitle = 'My urgent ticket!';
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+            'title' => $oldTitle,
+        ]);
+
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+        $crawler = $client->submitForm('form-update-title-submit', [
+            '_csrf_token' => 'not the token',
+            'title' => $newTitle,
+        ]);
+
+        $ticket->refresh();
+        $this->assertSame($oldTitle, $ticket->getTitle());
+    }
+}

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -78,3 +78,4 @@ Actions: Actions
 confidential: confidential
 solution: solution
 Type: Type
+'Rename the ticket': 'Rename the ticket'

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -78,3 +78,4 @@ Actions: Actions
 confidential: confidentiel
 solution: solution
 Type: Type
+'Rename the ticket': 'Renommer le ticket'


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/112

Changes proposed in this pull request:

- Create a new controller dedicated to edit the tickets titles
- Add a button in the "actions" menu to open the rename modal

How to test the feature manually:

1. Open a ticket
2. Open the actions menu and click on "rename the ticket"
3. Change the title of the ticket
4. Verify the title has changed

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
