### PR TITLE
imp: Improve and homogeneize colors of forms elements

### DIFF
--- a/assets/stylesheets/components/forms.css
+++ b/assets/stylesheets/components/forms.css
@@ -21,10 +21,12 @@ textarea {
 
     background-color: var(--color-grey1);
     box-shadow: 2px 2px 3px var(--color-box-shadow) inset;
-    border: 0.25rem solid var(--color-grey7);
+    border: 0.25rem solid var(--color-grey8);
     border-radius: 0.5rem;
 
-    transition: border-color 0.2s ease-in-out;
+    transition:
+        background-color 0.2s ease-in-out,
+        border-color 0.2s ease-in-out;
 }
 
 textarea {
@@ -32,8 +34,11 @@ textarea {
     min-height: 15rem;
 }
 
-input:focus,
-textarea:focus {
+input:not([disabled]):hover,
+input:not([disabled]):focus,
+textarea:not([disabled]):hover,
+textarea:not([disabled]):focus {
+    background-color: var(--color-primary2);
     border-color: var(--color-primary8);
 }
 
@@ -86,7 +91,7 @@ input[type="radio"] + label::before {
 
     background-color: var(--color-grey1);
     box-shadow: 2px 2px 3px var(--color-box-shadow) inset;
-    border: 0.25rem solid var(--color-grey7);
+    border: 0.25rem solid var(--color-grey8);
     border-radius: 0.5rem;
 
     transition:
@@ -153,7 +158,7 @@ select {
     text-overflow: ellipsis;
 
     background-color: var(--color-grey3);
-    border: 0.25rem solid var(--color-grey7);
+    border: 0.25rem solid var(--color-grey8);
     border-radius: 0.5rem;
 
     transition:
@@ -191,6 +196,17 @@ select:not([disabled]):focus {
 select[aria-invalid] {
     background-color: var(--color-error2);
     border-color: var(--color-error11);
+}
+
+.tox-tinymce {
+    border-color: var(--color-grey8) !important;
+
+    transition: border-color 0.2s ease-in-out;
+}
+
+.tox-tinymce:hover,
+.tox-tinymce:focus-within {
+    border-color: var(--color-primary8) !important;
 }
 
 .form-group--inline {


### PR DESCRIPTION
Changes proposed in this pull request:

- Set the main border colors to grey8 (better contrast)
- Set color on hover/focus to input
- Force the grey8 color for the TinyMCE editor main border

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
