### PR TITLE
imp: Allow to self-assign a ticket

### DIFF
--- a/assets/stylesheets/components/buttons.css
+++ b/assets/stylesheets/components/buttons.css
@@ -61,8 +61,10 @@ button:active,
     border-radius: 5rem;
 }
 
-.button--ghost {
+.button--anchor {
     padding: 0;
+
+    color: var(--color-primary11);
 
     background-color: transparent;
     background-image: none;
@@ -71,8 +73,8 @@ button:active,
     border-radius: 0;
 }
 
-.button--ghost:hover,
-.button--ghost:focus,
-.button--ghost:active {
+.button--anchor:hover,
+.button--anchor:focus,
+.button--anchor:active {
     background-color: transparent;
 }

--- a/assets/stylesheets/components/forms.css
+++ b/assets/stylesheets/components/forms.css
@@ -3,6 +3,10 @@
 /* Copyright 2022 Probesys */
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
 
+.form--inline {
+    display: inline-block;
+}
+
 label {
     display: block;
     padding-right: 0.75rem;

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -284,32 +284,42 @@
                     </div>
 
                     <div>
-                        <p class="text--secondary">
+                        <div class="text--secondary">
                             {{ 'Requester' | trans }}
-                        </p>
-                        <p>
+                        </div>
+
+                        <div>
                             {{ ticket.requester.email }}
-                        </p>
+                        </div>
                     </div>
 
                     <div>
-                        <p class="text--secondary">
+                        <div class="text--secondary">
                             {{ 'Assignee' | trans }}
-                        </p>
-                        <p>
+                        </div>
+
+                        <div>
                             {% if ticket.assignee %}
                                 {{ ticket.assignee.email }}
                             {% else %}
-                                <button
-                                    class="button--ghost"
-                                    data-controller="modal-opener"
-                                    data-action="modal-opener#fetch"
-                                    data-modal-opener-href-value="{{ path('edit ticket actors', { uid: ticket.uid }) }}"
+                                <strong>{{ 'Unassigned' | trans }}</strong>
+
+                                <form
+                                    action="{{ path('update ticket actors', { uid: ticket.uid }) }}"
+                                    method="post"
+                                    class="form--inline"
+                                    data-turbo-preserve-scroll
                                 >
-                                    <strong>{{ 'Unassigned' | trans }}</strong>
-                                </button>
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('update ticket actors') }}">
+                                    <input type="hidden" name="assigneeId" value="{{ app.user.id }}">
+
+                                    →
+                                    <button id="form-self-assign-submit" class="button--anchor" type="submit">
+                                        {{ 'assign yourself' | trans }}
+                                    </button>
+                                </form>
                             {% endif %}
-                        </p>
+                        </div>
                     </div>
                 </div>
 

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -82,3 +82,4 @@ Type: Type
 'You need to activate the JavaScript in order to use Bileto.': 'You need to activate the JavaScript in order to use Bileto.'
 'This ticket is resolved.': 'This ticket is resolved.'
 'This ticket is closed.': 'This ticket is closed.'
+'assign yourself': 'assign yourself'

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -82,3 +82,4 @@ Type: Type
 'You need to activate the JavaScript in order to use Bileto.': 'Vous devez activer le JavaScript pour utiliser Bileto.'
 'This ticket is resolved.': 'Ce ticket est résolu.'
 'This ticket is closed.': 'Ce ticket est clos.'
+'assign yourself': 'attribuez-vous'


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/143

Changes proposed in this pull request:

- Change button--ghost in button--anchor (color is changed to primary)
- Add a form to the "Actors" panel to assign an unassigned ticket to ourselves

How to test the feature manually:

1. Open a ticket, do not assign it
2. Click on "assign yourself"
3. Verify the ticket is now assigned to your current user

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
