### PR TITLE
imp: Add style to disabled buttons

### DIFF
--- a/assets/stylesheets/components/buttons.css
+++ b/assets/stylesheets/components/buttons.css
@@ -25,16 +25,28 @@ button,
     cursor: pointer;
 }
 
-button:hover,
-button:focus,
-.button:hover,
-.button:focus {
+button:not([disabled]):hover,
+button:not([disabled]):focus,
+.button:not([aria-disabled]):hover,
+.button:not([aria-disabled]):focus {
     background-color: var(--color-grey4);
 }
 
-button:active,
-.button:active {
+button:not([disabled]):active,
+.button:not([aria-disabled]):active {
     background-color: var(--color-grey5);
+}
+
+button[disabled],
+.button[aria-disabled] {
+    color: var(--color-grey11);
+
+    border-color: var(--color-grey7);
+
+    outline: none;
+
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 .button--primary {
@@ -44,13 +56,23 @@ button:active,
     border-color: var(--color-primary8);
 }
 
-.button--primary:hover,
-.button--primary:focus {
+.button--primary:not([disabled]):hover,
+.button--primary:not([disabled]):focus,
+.button--primary:not([aria-disabled]):hover,
+.button--primary:not([aria-disabled]):focus {
     background-color: var(--color-primary7);
 }
 
-.button--primary:active {
+.button--primary:not([disabled]):active,
+.button--primary:not([aria-disabled]):active {
     background-color: var(--color-primary8);
+}
+
+.button--primary[disabled],
+.button--primary[aria-disabled] {
+    color: var(--color-primary11);
+
+    border-color: var(--color-primary7);
 }
 
 .button--icon {


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/152

Changes proposed in this pull request:

- Don't apply hover, focus and active styles on disabled buttons
- Desaturate colours, change cursor, remove outline on disabled buttons

How to test the feature manually:

1. Create an organization
2. While the request is being made, verify the button has a different style

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
