### PR TITLE
tec: Fix GitHub Actions deprecations

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,10 +14,10 @@ runs:
     - name: Get composer cache directory
       id: composer-cache
       shell: bash
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,7 +21,7 @@ jobs:
         name: Lint PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup the CI
               uses: ./.github/actions/setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         name: Tests over PostgreSQL 14
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup the CI
               uses: ./.github/actions/setup
@@ -62,7 +62,7 @@ jobs:
         name: Tests over MariaDB 10.6
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup the CI
               uses: ./.github/actions/setup


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/63

Changes proposed in this pull request:

- Update actions/cache and actions/checkout
- Replace the `set-output` command by the new `$GITHUB_OUTPUT` environment file

How to test the feature manually:

1. Check that GitHub Actions don't raise warnings

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
