### PR TITLE
tec: Move factories under tests/ folder

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,3 +46,12 @@ when@dev:
         App\Twig\ViteTagsExtension:
             arguments:
                 - "%kernel.project_dir%/public/manifest.dev.json"
+
+when@test:
+    services:
+        _defaults:
+            autowire: true
+            autoconfigure: true
+
+        App\Tests\Factory\:
+            resource: '../tests/Factory'

--- a/tests/Command/Users/CreateCommandTest.php
+++ b/tests/Command/Users/CreateCommandTest.php
@@ -6,8 +6,8 @@
 
 namespace App\Tests\Command\Users;
 
-use App\Factory\UserFactory;
 use App\Tests\CommandTestsHelper;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Command\Command;
 use Zenstruck\Foundry\Test\Factories;

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -6,7 +6,7 @@
 
 namespace App\Tests\Controller;
 
-use App\Factory\UserFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -7,7 +7,7 @@
 namespace App\Tests\Controller;
 
 use App\Entity\User;
-use App\Factory\UserFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/Organizations/TicketsControllerTest.php
+++ b/tests/Controller/Organizations/TicketsControllerTest.php
@@ -8,10 +8,10 @@ namespace App\Tests\Controller\Organizations;
 
 use App\Entity\Organization;
 use App\Entity\Ticket;
-use App\Factory\MessageFactory;
-use App\Factory\OrganizationFactory;
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\MessageFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use App\Utils\Time;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Factory;

--- a/tests/Controller/OrganizationsControllerTest.php
+++ b/tests/Controller/OrganizationsControllerTest.php
@@ -7,8 +7,8 @@
 namespace App\Tests\Controller;
 
 use App\Entity\Organization;
-use App\Factory\OrganizationFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/PreferencesControllerTest.php
+++ b/tests/Controller/PreferencesControllerTest.php
@@ -7,7 +7,7 @@
 namespace App\Tests\Controller;
 
 use App\Entity\User;
-use App\Factory\UserFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/Tickets/ActorsControllerTest.php
+++ b/tests/Controller/Tickets/ActorsControllerTest.php
@@ -6,8 +6,8 @@
 
 namespace App\Tests\Controller\Tickets;
 
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/Tickets/MessagesControllerTest.php
+++ b/tests/Controller/Tickets/MessagesControllerTest.php
@@ -7,9 +7,9 @@
 namespace App\Tests\Controller\Tickets;
 
 use App\Entity\Ticket;
-use App\Factory\MessageFactory;
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\MessageFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use App\Utils\Time;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Factory;

--- a/tests/Controller/Tickets/PriorityControllerTest.php
+++ b/tests/Controller/Tickets/PriorityControllerTest.php
@@ -6,8 +6,8 @@
 
 namespace App\Tests\Controller\Tickets;
 
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/Tickets/TitleControllerTest.php
+++ b/tests/Controller/Tickets/TitleControllerTest.php
@@ -6,8 +6,8 @@
 
 namespace App\Tests\Controller\Tickets;
 
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/Tickets/TypeControllerTest.php
+++ b/tests/Controller/Tickets/TypeControllerTest.php
@@ -6,8 +6,8 @@
 
 namespace App\Tests\Controller\Tickets;
 
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Controller/TicketsControllerTest.php
+++ b/tests/Controller/TicketsControllerTest.php
@@ -7,9 +7,9 @@
 namespace App\Tests\Controller;
 
 use App\Entity\Organization;
-use App\Factory\OrganizationFactory;
-use App\Factory\TicketFactory;
-use App\Factory\UserFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;

--- a/tests/Factory/MessageFactory.php
+++ b/tests/Factory/MessageFactory.php
@@ -4,7 +4,7 @@
 // Copyright 2022 Probesys
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace App\Factory;
+namespace App\Tests\Factory;
 
 use App\Entity\Message;
 use App\Repository\MessageRepository;

--- a/tests/Factory/OrganizationFactory.php
+++ b/tests/Factory/OrganizationFactory.php
@@ -4,7 +4,7 @@
 // Copyright 2022 Probesys
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace App\Factory;
+namespace App\Tests\Factory;
 
 use App\Entity\Organization;
 use App\Repository\OrganizationRepository;

--- a/tests/Factory/TicketFactory.php
+++ b/tests/Factory/TicketFactory.php
@@ -4,7 +4,7 @@
 // Copyright 2022 Probesys
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace App\Factory;
+namespace App\Tests\Factory;
 
 use App\Entity\Ticket;
 use App\Repository\TicketRepository;

--- a/tests/Factory/UserFactory.php
+++ b/tests/Factory/UserFactory.php
@@ -4,7 +4,7 @@
 // Copyright 2022 Probesys
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace App\Factory;
+namespace App\Tests\Factory;
 
 use App\Entity\User;
 use App\Repository\UserRepository;


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/160

Changes proposed in this pull request:

- Move factories under tests/ folder
- Autowire / autoconfigure the App\Tests\Factory namespace

How to test the feature manually:

1. run the tests, check they pass

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
