### PR TITLE
imp: Detect preferred language from browser

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -36,6 +36,7 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         - { path: ^/login, role: PUBLIC_ACCESS }
+        - { path: ^/session/locale, role: PUBLIC_ACCESS }
         - { path: ^/, role: ROLE_USER }
 
 when@test:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,9 +26,6 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
-    App\EventSubscriber\LocaleSubscriber:
-        arguments: ['%kernel.default_locale%']
-
     App\Twig\ViteTagsExtension:
         arguments:
             - "%kernel.project_dir%/public/manifest.json"

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -6,6 +6,7 @@
 
 namespace App\Controller;
 
+use App\Utils\Locales;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -27,6 +28,7 @@ class LoginController extends BaseController
 
         return $this->render('login/new.html.twig', [
             'last_username' => $lastUsername,
+            'availableLanguages' => Locales::getSupportedLanguages(),
             'error' => $error,
         ]);
     }

--- a/src/Controller/PreferencesController.php
+++ b/src/Controller/PreferencesController.php
@@ -7,6 +7,7 @@
 namespace App\Controller;
 
 use App\Repository\UserRepository;
+use App\Utils\Locales;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,6 +24,7 @@ class PreferencesController extends BaseController
         return $this->render('preferences/edit.html.twig', [
             'colorScheme' => $user->getColorScheme(),
             'locale' => $user->getLocale(),
+            'availableLanguages' => Locales::getSupportedLanguages(),
         ]);
     }
 
@@ -49,6 +51,7 @@ class PreferencesController extends BaseController
             return $this->renderBadRequest('preferences/edit.html.twig', [
                 'colorScheme' => $colorScheme,
                 'locale' => $locale,
+                'availableLanguages' => Locales::getSupportedLanguages(),
                 'error' => $this->csrfError(),
             ]);
         }
@@ -63,6 +66,7 @@ class PreferencesController extends BaseController
             return $this->renderBadRequest('preferences/edit.html.twig', [
                 'colorScheme' => $colorScheme,
                 'locale' => $locale,
+                'availableLanguages' => Locales::getSupportedLanguages(),
                 'errors' => $this->formatErrors($errors),
             ]);
         }

--- a/src/Controller/SessionController.php
+++ b/src/Controller/SessionController.php
@@ -1,0 +1,45 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Controller;
+
+use App\Utils\Locales;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SessionController extends BaseController
+{
+    #[Route('/session/locale', name: 'update session locale', methods: ['POST'])]
+    public function updateLocale(
+        Request $request,
+        RequestStack $requestStack,
+    ): Response {
+        /** @var string $locale */
+        $locale = $request->request->get('locale', $request->getLocale());
+
+        /** @var string $from */
+        $from = $request->request->get('from', 'home');
+
+        /** @var string $csrfToken */
+        $csrfToken = $request->request->get('_csrf_token', '');
+
+        if (!$this->isCsrfTokenValid('update session locale', $csrfToken)) {
+            return $this->redirectToRoute($from);
+        }
+
+        if (!Locales::isAvailable($locale)) {
+            return $this->redirectToRoute($from);
+        }
+
+        $session = $requestStack->getSession();
+        $session->set('_locale', $locale);
+
+        return $this->redirectToRoute($from);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -7,6 +7,7 @@
 namespace App\Entity;
 
 use App\Repository\UserRepository;
+use App\Utils\Locales;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -62,15 +63,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     )]
     private ?string $colorScheme = 'auto';
 
-    #[ORM\Column(length: 5, options: ['default' => 'en_GB'])]
+    #[ORM\Column(length: 5, options: ['default' => Locales::DEFAULT_LOCALE])]
     #[Assert\NotBlank(
         message: new TranslatableMessage('The language is required.', [], 'validators'),
     )]
     #[Assert\Choice(
-        choices: ['en_GB', 'fr_FR'],
+        choices: Locales::SUPPORTED_LOCALES,
         message: new TranslatableMessage('The language {{ value }} is not a valid choice.', [], 'validators'),
     )]
-    private ?string $locale = 'en_GB';
+    private ?string $locale = Locales::DEFAULT_LOCALE;
 
     #[ORM\Column(length: 20, unique: true)]
     private ?string $uid = null;

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -6,28 +6,24 @@
 
 namespace App\EventSubscriber;
 
+use App\Utils\Locales;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class LocaleSubscriber implements EventSubscriberInterface
 {
-    private string $defaultLocale;
-
-    public function __construct(string $defaultLocale)
-    {
-        $this->defaultLocale = $defaultLocale;
-    }
-
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->hasPreviousSession()) {
-            return;
-        }
 
-        $locale = $request->getSession()->get('_locale', $this->defaultLocale);
-        $request->setLocale($locale);
+        $preferredLocale = Locales::getBest($request->getLanguages());
+        if ($request->hasPreviousSession()) {
+            $locale = $request->getSession()->get('_locale', $preferredLocale);
+            $request->setLocale($locale);
+        } else {
+            $request->setLocale($preferredLocale);
+        }
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Utils/Locales.php
+++ b/src/Utils/Locales.php
@@ -27,4 +27,50 @@ class Locales
     {
         return in_array($locale, self::SUPPORTED_LOCALES);
     }
+
+    /**
+     * @param string[] $requestedLocales
+     */
+    public static function getBest(array $requestedLocales): string
+    {
+        // First, look for an exact match in the supported locales:
+        foreach ($requestedLocales as $locale) {
+            if (self::isAvailable($locale)) {
+                return $locale;
+            }
+        }
+
+        // Then, create an array to match "super" locales (e.g. en) to
+        // supported country locales (e.g. en_GB):
+        $supersToLocales = [];
+        foreach (self::SUPPORTED_LOCALES as $locale) {
+            $splitLocale = explode('_', $locale, 2);
+            if (count($splitLocale) < 2) {
+                continue;
+            }
+
+            $superLocale = $splitLocale[0];
+            if (!isset($supersToLocales[$superLocale])) {
+                $supersToLocales[$superLocale] = $locale;
+            }
+        }
+
+        // And search requested locales in the lookup array:
+        foreach ($requestedLocales as $locale) {
+            $splitLocale = explode('_', $locale, 2);
+            if (count($splitLocale) === 1) {
+                $superLocale = $locale;
+            } else {
+                $superLocale = $splitLocale[0];
+            }
+
+            if (isset($supersToLocales[$superLocale])) {
+                return $supersToLocales[$superLocale];
+            }
+        }
+
+        // Bileto doesn't support the requested locales, let's return the
+        // default one.
+        return self::DEFAULT_LOCALE;
+    }
 }

--- a/src/Utils/Locales.php
+++ b/src/Utils/Locales.php
@@ -1,0 +1,30 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Utils;
+
+class Locales
+{
+    public const DEFAULT_LOCALE = 'en_GB';
+
+    public const SUPPORTED_LOCALES = ['en_GB', 'fr_FR'];
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSupportedLanguages(): array
+    {
+        return [
+            'en_GB' => 'English',
+            'fr_FR' => 'Français',
+        ];
+    }
+
+    public static function isAvailable(string $locale): bool
+    {
+        return in_array($locale, self::SUPPORTED_LOCALES);
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -77,6 +77,40 @@
                                 </form>
                             </nav>
                         </details>
+                    {% else %}
+                        <div class="layout__header-extend"></div>
+
+                        <details
+                            class="popup"
+                            data-controller="popup"
+                            data-action="toggle->popup#update click@window->popup#closeOnClickOutside"
+                        >
+                            <summary class="popup__opener">
+                                <span class="button">
+                                    {{ icon('language') }}
+                                    {{ 'Language' | trans }}
+                                </span>
+                            </summary>
+
+                            <nav class="popup__container popup__container--left">
+                                <form action="{{ path('update session locale') }}" method="post">
+                                    {% for locale, language in availableLanguages %}
+                                        <button
+                                            id="form-update-session-locale-{{ locale }}-submit"
+                                            class="popup__item"
+                                            type="submit"
+                                            name="locale"
+                                            value="{{ locale }}"
+                                        >
+                                            {{ language }}
+                                        </button>
+                                    {% endfor %}
+
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('update session locale') }}">
+                                    <input type="hidden" name="from" value="{{ app.request.get('_route') }}">
+                                </form>
+                            </nav>
+                        </details>
                     {% endif %}
                 </div>
             </nav>

--- a/templates/preferences/edit.html.twig
+++ b/templates/preferences/edit.html.twig
@@ -46,12 +46,11 @@
                         aria-errormessage="locale-error"
                     {% endif %}
                 >
-                    <option value="en_GB" {{ locale == 'en_GB' ? 'selected' }}>
-                        English
-                    </option>
-                    <option value="fr_FR" {{ locale == 'fr_FR' ? 'selected' }}>
-                        Français
-                    </option>
+                    {% for locale_, language in availableLanguages %}
+                        <option value="{{ locale_ }}" {{ locale == locale_ ? 'selected' }}>
+                            {{ language }}
+                        </option>
+                    {% endfor %}
                 </select>
             </div>
 

--- a/tests/Controller/SessionControllerTest.php
+++ b/tests/Controller/SessionControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Controller;
+
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class SessionControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    public function testPostUpdateLocaleSavesTheLocaleInTheSessionAndRedirects(): void
+    {
+        $client = static::createClient();
+        $session = $this->createSession($client);
+
+        $client->request('GET', '/login');
+        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit');
+
+        $this->assertResponseRedirects('/login', 302);
+        $this->assertSame('fr_FR', $session->get('_locale'));
+    }
+
+    public function testPostUpdateLocaleFailsIfLocaleIsInvalid(): void
+    {
+        $client = static::createClient();
+        $session = $this->createSession($client);
+
+        $client->request('GET', '/login');
+        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit', [
+            'locale' => 'unsupported',
+        ]);
+
+        $this->assertResponseRedirects('/login', 302);
+        $this->assertNull($session->get('_locale'));
+    }
+
+    public function testPostUpdateLocaleFailsIfCsrfIsInvalid(): void
+    {
+        $client = static::createClient();
+        $session = $this->createSession($client);
+
+        $client->request('GET', '/login');
+        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit', [
+            '_csrf_token' => 'not the token',
+        ]);
+
+        $this->assertResponseRedirects('/login', 302);
+        $this->assertNull($session->get('_locale'));
+    }
+}

--- a/tests/SessionHelper.php
+++ b/tests/SessionHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+
+trait SessionHelper
+{
+    public function createSession(KernelBrowser $client): Session
+    {
+        $container = $client->getContainer();
+        /** @var string $sessionSavePath */
+        $sessionSavePath = $container->getParameter('session.save_path');
+        $sessionStorage = new MockFileSessionStorage($sessionSavePath);
+        $session = new Session($sessionStorage);
+
+        $session->start();
+        $session->save();
+        $sessionCookie = new Cookie(
+            $session->getName(),
+            $session->getId(),
+            null,
+            null,
+            'localhost',
+        );
+        $client->getCookieJar()->set($sessionCookie);
+
+        return $session;
+    }
+}

--- a/tests/Utils/LocalesTest.php
+++ b/tests/Utils/LocalesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Utils;
+
+use App\Utils\Locales;
+use PHPUnit\Framework\TestCase;
+
+class LocalesTest extends TestCase
+{
+    /**
+     * @dataProvider englishRequestedLocale
+     *
+     * @param string[] $requestedLocales
+     */
+    public function testGetBestWithEnglish(array $requestedLocales): void
+    {
+        $locale = Locales::getBest($requestedLocales);
+
+        $this->assertSame('en_GB', $locale);
+    }
+
+    /**
+     * @dataProvider frenchRequestedLocale
+     *
+     * @param string[] $requestedLocales
+     */
+    public function testGetBestWithFrench(array $requestedLocales): void
+    {
+        $locale = Locales::getBest($requestedLocales);
+
+        $this->assertSame('fr_FR', $locale);
+    }
+
+    /**
+     * @return string[][][]
+     */
+    public function englishRequestedLocale(): array
+    {
+        return [
+            [[]],
+            [['']],
+            [['àà']],
+            [['en_GB']],
+            [['en_US']],
+            [['en_GB', 'fr_FR']],
+            [['fr', 'en_GB']],
+            [['de_DE']],
+        ];
+    }
+
+    /**
+     * @return string[][][]
+     */
+    public function frenchRequestedLocale(): array
+    {
+        return [
+            [['fr_FR']],
+            [['fr_BE']],
+            [['fr']],
+            [['fr_FR', 'en_GB']],
+            [['en', 'fr_FR']],
+        ];
+    }
+}


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/86

Changes proposed in this pull request:

- Rework how the supported locales are handled
- Calculate the best supported locale from the `Accept-Language` HTTP header
- Allow to change the session locale from the login form

How to test the feature manually:

1. Disconnect from Bileto and/or empty your cookies
2. Verify the locale corresponds to your browser preferences
3. Change the order of French and English languages in your browser preferences, and verify Bileto is generated with the correct locale

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
