### PR TITLE
new: Add a "skip to main content" accessibility anchor

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -96,6 +96,26 @@ body {
     }
 }
 
+.accessibility-nav {
+    position: absolute;
+
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+
+    width: 1px;
+    height: 1px;
+}
+
+.accessibility-nav:focus {
+    top: 1rem;
+    left: 1rem;
+
+    clip: auto;
+
+    width: auto;
+    height: auto;
+}
+
 .turbo-progress-bar {
     position: fixed;
     top: 0;

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -28,6 +28,15 @@
     </head>
 
     <body>
+        <a
+            class="no-mobile accessibility-nav anchor--action"
+            href="#main-content"
+            tabindex="0"
+            data-turbo="false"
+        >
+            {{ 'Skip to main content' | trans }}
+        </a>
+
         <div class="layout" id="layout">
             <noscript>
                 <div class="layout__banner layout__banner--alert">
@@ -121,7 +130,9 @@
                 </div>
             {% endif %}
 
-            {% block body %}{% endblock %}
+            <div id="main-content">
+                {% block body %}{% endblock %}
+            </div>
         </div>
 
         {{ include('_modal_dialog.html.twig') }}

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -84,3 +84,4 @@ Type: Type
 'This ticket is closed.': 'This ticket is closed.'
 'assign yourself': 'assign yourself'
 (yourself): (yourself)
+'Skip to main content': 'Skip to main content'

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -84,3 +84,4 @@ Type: Type
 'This ticket is closed.': 'Ce ticket est clos.'
 'assign yourself': attribuez-vous
 (yourself): (vous)
+'Skip to main content': 'Accéder au contenu principal'


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/95

Changes proposed in this pull request:

- Add a link to the top of the page to give the focus to the main content (accessible with the keyboard)

How to test the feature manually:

1. load Bileto in your browser
2. navigate with the <kbd>tab</kbd> key to access the "skip to main content" anchor
3. press <kbd>enter</kbd>, then <kbd>tab</kbd> again
4. verify the focus is given to the first element of the main content

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
