### PR TITLE
tec: Add more Controller tests

### DIFF
--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -100,11 +100,11 @@ class TicketsController extends BaseController
         $messageContent = $request->request->get('message', '');
         $messageContent = $appMessageSanitizer->sanitize($messageContent);
 
-        /** @var string $requesterId */
-        $requesterId = $request->request->get('requesterId', '');
+        /** @var int $requesterId */
+        $requesterId = $request->request->getInt('requesterId', 0);
 
-        /** @var string $assigneeId */
-        $assigneeId = $request->request->get('assigneeId', '');
+        /** @var int $assigneeId */
+        $assigneeId = $request->request->getInt('assigneeId', 0);
 
         /** @var string $status */
         $status = $request->request->get('status', 'new');

--- a/src/Controller/Tickets/ActorsController.php
+++ b/src/Controller/Tickets/ActorsController.php
@@ -45,11 +45,11 @@ class ActorsController extends BaseController
         $initialRequester = $ticket->getRequester();
         $initialAssignee = $ticket->getAssignee();
 
-        /** @var string $requesterId */
-        $requesterId = $request->request->get('requesterId', $initialRequester ? $initialRequester->getId() : '');
+        /** @var int $requesterId */
+        $requesterId = $request->request->getInt('requesterId', $initialRequester ? $initialRequester->getId() : 0);
 
-        /** @var string $assigneeId */
-        $assigneeId = $request->request->get('assigneeId', $initialAssignee ? $initialAssignee->getId() : '');
+        /** @var int $assigneeId */
+        $assigneeId = $request->request->getInt('assigneeId', $initialAssignee ? $initialAssignee->getId() : 0);
 
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');

--- a/src/Controller/Tickets/MessagesController.php
+++ b/src/Controller/Tickets/MessagesController.php
@@ -37,10 +37,10 @@ class MessagesController extends BaseController
         $messageContent = $appMessageSanitizer->sanitize($messageContent);
 
         /** @var boolean $isSolution */
-        $isSolution = $request->request->get('isSolution', false);
+        $isSolution = $request->request->getBoolean('isSolution', false);
 
         /** @var boolean $isConfidential */
-        $isConfidential = $request->request->get('isConfidential', false);
+        $isConfidential = $request->request->getBoolean('isConfidential', false);
 
         /** @var string $status */
         $status = $request->request->get('status', '');
@@ -104,13 +104,16 @@ class MessagesController extends BaseController
             $status = 'resolved';
         }
 
+        $initialStatus = $ticket->getStatus();
         $ticket->setStatus($status);
 
         $errors = $validator->validate($ticket);
         if (count($errors) > 0) {
-            return $this->renderBadRequest('tickets/messages/_messages.html.twig', [
+            $ticket->setStatus($initialStatus);
+            return $this->renderBadRequest('tickets/show.html.twig', [
                 'ticket' => $ticket,
                 'messages' => $ticket->getMessages(),
+                'organization' => $ticket->getOrganization(),
                 'message' => $messageContent,
                 'status' => $status,
                 'statuses' => $statuses,

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -177,29 +177,38 @@
 
                     <div class="row">
                         {% if not ticket.isFinished %}
-                            <div class="row__item--extend row row--center row--always">
-                                <label for="status">
-                                    {{ 'Status to' | trans }}
-                                </label>
+                            <div class="row__item--extend flow-small">
+                                <div class="row row--center row--always">
+                                    <label for="status">
+                                        {{ 'Status to' | trans }}
+                                    </label>
 
-                                <select
-                                    id="status"
-                                    name="status"
-                                    required
-                                    {{ ticket.isFinished ? 'disabled' }}
-                                    {% if errors.status is defined %}
-                                        autofocus
-                                        aria-invalid="true"
-                                        aria-errormessage="status-error"
-                                    {% endif %}
-                                    data-ticket-editor-target="statusSelect"
-                                >
-                                    {% for value, label in statuses %}
-                                        <option value="{{ value }}" {{ value == status ? 'selected' }}>
-                                            {{ label | trans }}
-                                        </option>
-                                    {% endfor %}
-                                </select>
+                                    <select
+                                        id="status"
+                                        name="status"
+                                        required
+                                        {{ ticket.isFinished ? 'disabled' }}
+                                        {% if errors.status is defined %}
+                                            autofocus
+                                            aria-invalid="true"
+                                            aria-errormessage="status-error"
+                                        {% endif %}
+                                        data-ticket-editor-target="statusSelect"
+                                    >
+                                        {% for value, label in statuses %}
+                                            <option value="{{ value }}" {{ value == status ? 'selected' }}>
+                                                {{ label | trans }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                                {% if errors.status is defined %}
+                                    <p class="form__error" role="alert" id="status-error">
+                                        <span class="sr-only">{{ 'Error' | trans }}</span>
+                                        {{ errors.status }}
+                                    </p>
+                                {% endif %}
                             </div>
                         {% elseif ticket.status == 'resolved' %}
                             <p class="row__item--extend text--success">

--- a/tests/Controller/OrganizationsControllerTest.php
+++ b/tests/Controller/OrganizationsControllerTest.php
@@ -9,6 +9,7 @@ namespace App\Tests\Controller;
 use App\Entity\Organization;
 use App\Tests\Factory\OrganizationFactory;
 use App\Tests\Factory\UserFactory;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -17,6 +18,7 @@ class OrganizationsControllerTest extends WebTestCase
 {
     use Factories;
     use ResetDatabase;
+    use SessionHelper;
 
     public function testGetIndexListsOrganizationsSortedByName(): void
     {
@@ -108,8 +110,8 @@ class OrganizationsControllerTest extends WebTestCase
         $client->loginUser($user->object());
         $name = '';
 
-        $client->request('GET', '/organizations/new');
-        $crawler = $client->submitForm('form-create-organization-submit', [
+        $client->request('POST', '/organizations/new', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'create organization'),
             'name' => $name,
         ]);
 
@@ -127,8 +129,8 @@ class OrganizationsControllerTest extends WebTestCase
             'name' => $name,
         ]);
 
-        $client->request('GET', '/organizations/new');
-        $crawler = $client->submitForm('form-create-organization-submit', [
+        $client->request('POST', '/organizations/new', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'create organization'),
             'name' => $name,
         ]);
 
@@ -143,8 +145,8 @@ class OrganizationsControllerTest extends WebTestCase
         $client->loginUser($user->object());
         $name = str_repeat('a', 256);
 
-        $client->request('GET', '/organizations/new');
-        $crawler = $client->submitForm('form-create-organization-submit', [
+        $client->request('POST', '/organizations/new', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'create organization'),
             'name' => $name,
         ]);
 
@@ -159,9 +161,8 @@ class OrganizationsControllerTest extends WebTestCase
         $client->loginUser($user->object());
         $name = 'My organization';
 
-        $client->request('GET', '/organizations/new');
-        $crawler = $client->submitForm('form-create-organization-submit', [
-            '_csrf_token' => 'not the token',
+        $client->request('POST', '/organizations/new', [
+            '_csrf_token' => 'not a token',
             'name' => $name,
         ]);
 

--- a/tests/Controller/SessionControllerTest.php
+++ b/tests/Controller/SessionControllerTest.php
@@ -16,10 +16,13 @@ class SessionControllerTest extends WebTestCase
     public function testPostUpdateLocaleSavesTheLocaleInTheSessionAndRedirects(): void
     {
         $client = static::createClient();
-        $session = $this->createSession($client);
+        $session = $this->getSession($client);
 
-        $client->request('GET', '/login');
-        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit');
+        $client->request('POST', '/session/locale', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update session locale'),
+            'locale' => 'fr_FR',
+            'from' => 'login',
+        ]);
 
         $this->assertResponseRedirects('/login', 302);
         $this->assertSame('fr_FR', $session->get('_locale'));
@@ -28,11 +31,12 @@ class SessionControllerTest extends WebTestCase
     public function testPostUpdateLocaleFailsIfLocaleIsInvalid(): void
     {
         $client = static::createClient();
-        $session = $this->createSession($client);
+        $session = $this->getSession($client);
 
-        $client->request('GET', '/login');
-        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit', [
+        $client->request('POST', '/session/locale', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update session locale'),
             'locale' => 'unsupported',
+            'from' => 'login',
         ]);
 
         $this->assertResponseRedirects('/login', 302);
@@ -42,11 +46,12 @@ class SessionControllerTest extends WebTestCase
     public function testPostUpdateLocaleFailsIfCsrfIsInvalid(): void
     {
         $client = static::createClient();
-        $session = $this->createSession($client);
+        $session = $this->getSession($client);
 
-        $client->request('GET', '/login');
-        $crawler = $client->submitForm('form-update-session-locale-fr_FR-submit', [
+        $client->request('POST', '/session/locale', [
             '_csrf_token' => 'not the token',
+            'locale' => 'fr_FR',
+            'from' => 'login',
         ]);
 
         $this->assertResponseRedirects('/login', 302);

--- a/tests/Controller/Tickets/PriorityControllerTest.php
+++ b/tests/Controller/Tickets/PriorityControllerTest.php
@@ -8,6 +8,7 @@ namespace App\Tests\Controller\Tickets;
 
 use App\Tests\Factory\TicketFactory;
 use App\Tests\Factory\UserFactory;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -16,6 +17,7 @@ class PriorityControllerTest extends WebTestCase
 {
     use Factories;
     use ResetDatabase;
+    use SessionHelper;
 
     public function testGetEditRendersCorrectly(): void
     {
@@ -77,6 +79,38 @@ class PriorityControllerTest extends WebTestCase
         $this->assertSame($newPriority, $ticket->getPriority());
     }
 
+    public function testPostUpdateFailsIfPriorityIsInvalid(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $oldUrgency = 'low';
+        $oldImpact = 'low';
+        $oldPriority = 'low';
+        $newUrgency = 'low';
+        $newImpact = 'high';
+        $newPriority = 'invalid';
+        $ticket = TicketFactory::createOne([
+            'createdBy' => $user,
+            'urgency' => $oldUrgency,
+            'impact' => $oldImpact,
+            'priority' => $oldPriority,
+        ]);
+
+        $client->request('POST', "/tickets/{$ticket->getUid()}/priority/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket priority'),
+            'urgency' => $newUrgency,
+            'impact' => $newImpact,
+            'priority' => $newPriority,
+        ]);
+
+        $this->assertSelectorTextContains('#priority-error', 'The priority "invalid" is not a valid priority.');
+        $ticket->refresh();
+        $this->assertSame($oldUrgency, $ticket->getUrgency());
+        $this->assertSame($oldImpact, $ticket->getImpact());
+        $this->assertSame($oldPriority, $ticket->getPriority());
+    }
+
     public function testPostUpdateFailsIfCsrfTokenIsInvalid(): void
     {
         $client = static::createClient();
@@ -95,14 +129,14 @@ class PriorityControllerTest extends WebTestCase
             'priority' => $oldPriority,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}/priority/edit");
-        $crawler = $client->submitForm('form-update-priority-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/priority/edit", [
             '_csrf_token' => 'not the token',
             'urgency' => $newUrgency,
             'impact' => $newImpact,
             'priority' => $newPriority,
         ]);
 
+        $this->assertSelectorTextContains('[data-test="alert-error"]', 'Invalid CSRF token.');
         $ticket->refresh();
         $this->assertSame($oldUrgency, $ticket->getUrgency());
         $this->assertSame($oldImpact, $ticket->getImpact());

--- a/tests/Controller/Tickets/TitleControllerTest.php
+++ b/tests/Controller/Tickets/TitleControllerTest.php
@@ -8,6 +8,7 @@ namespace App\Tests\Controller\Tickets;
 
 use App\Tests\Factory\TicketFactory;
 use App\Tests\Factory\UserFactory;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -16,6 +17,7 @@ class TitleControllerTest extends WebTestCase
 {
     use Factories;
     use ResetDatabase;
+    use SessionHelper;
 
     public function testGetEditRendersCorrectly(): void
     {
@@ -79,8 +81,8 @@ class TitleControllerTest extends WebTestCase
             'title' => $oldTitle,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
-        $crawler = $client->submitForm('form-update-title-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/title/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket title'),
             'title' => $newTitle,
         ]);
 
@@ -101,12 +103,12 @@ class TitleControllerTest extends WebTestCase
             'title' => $oldTitle,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
-        $crawler = $client->submitForm('form-update-title-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/title/edit", [
             '_csrf_token' => 'not the token',
             'title' => $newTitle,
         ]);
 
+        $this->assertSelectorTextContains('[data-test="alert-error"]', 'Invalid CSRF token.');
         $ticket->refresh();
         $this->assertSame($oldTitle, $ticket->getTitle());
     }

--- a/tests/Controller/Tickets/TypeControllerTest.php
+++ b/tests/Controller/Tickets/TypeControllerTest.php
@@ -8,6 +8,7 @@ namespace App\Tests\Controller\Tickets;
 
 use App\Tests\Factory\TicketFactory;
 use App\Tests\Factory\UserFactory;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -16,6 +17,7 @@ class TypeControllerTest extends WebTestCase
 {
     use Factories;
     use ResetDatabase;
+    use SessionHelper;
 
     public function testPostUpdateSavesTicketAndRedirects(): void
     {
@@ -49,8 +51,8 @@ class TypeControllerTest extends WebTestCase
             'type' => $oldType,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}");
-        $crawler = $client->submitForm('form-update-type-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/type/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket type'),
             'type' => $newType,
         ]);
 
@@ -65,14 +67,15 @@ class TypeControllerTest extends WebTestCase
         $user = UserFactory::createOne();
         $client->loginUser($user->object());
         $oldType = 'request';
+        $newType = 'incident';
         $ticket = TicketFactory::createOne([
             'createdBy' => $user,
             'type' => $oldType,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}");
-        $crawler = $client->submitForm('form-update-type-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/type/edit", [
             '_csrf_token' => 'not the token',
+            'type' => $newType,
         ]);
 
         $this->assertResponseRedirects("/tickets/{$ticket->getUid()}", 302);

--- a/tests/SessionHelper.php
+++ b/tests/SessionHelper.php
@@ -10,19 +10,30 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 
 trait SessionHelper
 {
+    public function getSession(KernelBrowser $client): Session
+    {
+        $cookie = $client->getCookieJar()->get('MOCKSESSID');
+        if ($cookie) {
+            $session = $this->initSession();
+            $session->setId($cookie->getValue());
+            $session->start();
+            return $session;
+        } else {
+            return self::createSession($client);
+        }
+    }
+
     public function createSession(KernelBrowser $client): Session
     {
-        $container = $client->getContainer();
-        /** @var string $sessionSavePath */
-        $sessionSavePath = $container->getParameter('session.save_path');
-        $sessionStorage = new MockFileSessionStorage($sessionSavePath);
-        $session = new Session($sessionStorage);
-
+        $session = $this->initSession();
         $session->start();
         $session->save();
+
         $sessionCookie = new Cookie(
             $session->getName(),
             $session->getId(),
@@ -33,5 +44,26 @@ trait SessionHelper
         $client->getCookieJar()->set($sessionCookie);
 
         return $session;
+    }
+
+    private function initSession(): Session
+    {
+        $container = static::getContainer();
+        /** @var string $sessionSavePath */
+        $sessionSavePath = $container->getParameter('session.save_path');
+        $sessionStorage = new MockFileSessionStorage($sessionSavePath);
+        return new Session($sessionStorage);
+    }
+
+    public function generateCsrfToken(KernelBrowser $client, string $tokenId): string
+    {
+        $session = $this->getSession($client);
+        $container = static::getContainer();
+        /** @var TokenGeneratorInterface $tokenGenerator */
+        $tokenGenerator = $container->get('security.csrf.token_generator');
+        $csrfToken = $tokenGenerator->generateToken();
+        $session->set(SessionTokenStorage::SESSION_NAMESPACE . "/{$tokenId}", $csrfToken);
+        $session->save();
+        return $csrfToken;
     }
 }


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/161

Changes proposed in this pull request:

- Add a `getSession` and a `generateCsrfToken` methods to `SessionHelper`
- Use `generateCsrfToken` in the tests in order to test controllers endpoints directly with `$client->request()`
- Add missing tests (e.g. for invalid values of selectboxes)
- Make sure to use the correct types when retrieving parameters from request
- Render correctly the errors on status when answering

How to test the feature manually: N/A

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
