### PR TITLE
New/orga tree

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -14,6 +14,7 @@
 @import "./components/anchors.css";
 @import "./components/badges.css";
 @import "./components/buttons.css";
+@import "./components/breadcrumbs.css";
 @import "./components/cards.css";
 @import "./components/forms.css";
 @import "./components/icons.css";

--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -57,7 +57,7 @@ body {
         Cantarell,
         "Helvetica Neue",
         sans-serif;
-    font-size: 18px;
+    font-size: 20px;
 
     background: var(--color-grey2);
 }

--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -29,6 +29,7 @@
 @import "./components/tickets.css";
 @import "./components/timelines.css";
 @import "./pages/login-new.css";
+@import "./pages/organizations-index.css";
 @import "./pages/tickets-index.css";
 @import "./pages/tickets-show.css";
 

--- a/assets/stylesheets/components/breadcrumbs.css
+++ b/assets/stylesheets/components/breadcrumbs.css
@@ -1,0 +1,41 @@
+/* This file is part of Bileto. */
+/* Copyright 2022-2023 Probesys */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+
+.breadcrumb__list {
+    padding-left: 0;
+
+    text-align: center;
+
+    list-style: none;
+}
+
+.breadcrumb__item {
+    display: inline-block;
+}
+
+.breadcrumb__item:not(:last-child)::after {
+    content: "";
+
+    display: inline-block;
+    height: 2rem;
+    margin-right: 0.75rem;
+    margin-bottom: -0.3rem;
+    margin-left: 0.75rem;
+
+    border-right: 0.25rem solid var(--color-grey11);
+
+    transform: rotate(25deg);
+}
+
+.breadcrumb__item--active {
+    font-weight: bold;
+}
+
+.breadcrumb__item:not(.breadcrumb__item--active) {
+    color: var(--color-grey11);
+}
+
+.breadcrumb__anchor {
+    text-decoration: none;
+}

--- a/assets/stylesheets/components/cards.css
+++ b/assets/stylesheets/components/cards.css
@@ -5,27 +5,35 @@
 .card {
     overflow: hidden;
 
+    display: flex;
     padding: 2rem 1rem;
 
-    background-color: var(--color-grey3);
+    flex-direction: column;
+    align-items: stretch;
+
+    background-color: var(--color-grey2);
     box-shadow: 1px 1px 2px 1px var(--color-box-shadow);
     border-radius: 0.5rem;
 }
 
-a.card {
-    text-decoration: none;
-}
-
-a.card:hover,
-a.card:focus {
-    background-color: var(--color-grey4);
-}
-
-a.card:active {
-    background-color: var(--color-grey5);
-}
-
 .card__title {
+    display: block;
+    margin-top: -0.5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+
+    font-size: 1.1em;
     font-weight: bold;
+    text-align: center;
     overflow-wrap: anywhere;
+}
+
+a.card__title {
+    text-decoration: none;
+
+    outline-offset: -0.3rem;
+}
+
+.card__body {
+    flex: 1;
 }

--- a/assets/stylesheets/components/popups.css
+++ b/assets/stylesheets/components/popups.css
@@ -121,7 +121,7 @@
 .popup__item {
     display: block;
     width: 100%;
-    padding: 0.75rem 1.5rem;
+    padding: 1rem 1.5rem;
 
     color: var(--color-grey12);
     line-height: 1.5;

--- a/assets/stylesheets/pages/organizations-index.css
+++ b/assets/stylesheets/pages/organizations-index.css
@@ -1,0 +1,43 @@
+/* This file is part of Bileto. */
+/* Copyright 2022-2023 Probesys */
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+
+.organizations-index .organizations__list {
+    position: relative;
+
+    padding-left: 0;
+
+    border-left: 0.25rem solid var(--color-primary7);
+
+    list-style: none;
+}
+
+.organizations-index .organizations__list .organizations__list {
+    margin-left: 1rem;
+
+    font-size: 0.9em;
+
+    background-color: var(--color-grey3);
+}
+
+.organizations-index .organizations__list-item a {
+    display: block;
+    margin-left: -0.25rem;
+    padding: 1rem;
+
+    line-height: 1;
+    text-decoration: none;
+
+    border-left: 0.25rem solid transparent;
+    outline-offset: -0.3rem;
+
+    transition:
+        background-color 0.2s ease-in-out,
+        border-color 0.2s ease-in-out;
+}
+
+.organizations-index .organizations__list-item a:hover,
+.organizations-index .organizations__list-item a:focus {
+    background-color: var(--color-primary4);
+    border-left-color: var(--color-primary8);
+}

--- a/migrations/Version20230104101215AddParentsPathToOrganization.php
+++ b/migrations/Version20230104101215AddParentsPathToOrganization.php
@@ -1,0 +1,30 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230104101215AddParentsPathToOrganization extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the parents_path column to the organization table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE organization ADD parents_path VARCHAR(255) NOT NULL DEFAULT '/'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organization DROP parents_path');
+    }
+}

--- a/migrations/Version20230106093003RemoveOrganizationNameUniqueness.php
+++ b/migrations/Version20230106093003RemoveOrganizationNameUniqueness.php
@@ -1,0 +1,35 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230106093003RemoveOrganizationNameUniqueness extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove the unique index on the organization name column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform()->getName();
+        if ($dbPlatform === 'postgresql') {
+            $this->addSql('DROP INDEX UNIQ_C1EE637C5E237E06');
+        } elseif ($dbPlatform === 'mysql') {
+            $this->addSql('DROP INDEX UNIQ_C1EE637C5E237E06 on `organization`');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_C1EE637C5E237E06 ON organization (name)');
+    }
+}

--- a/src/Controller/OrganizationsController.php
+++ b/src/Controller/OrganizationsController.php
@@ -19,7 +19,7 @@ class OrganizationsController extends BaseController
     #[Route('/organizations', name: 'organizations', methods: ['GET', 'HEAD'])]
     public function index(OrganizationRepository $orgaRepository): Response
     {
-        $organizations = $orgaRepository->findBy([], ['name' => 'ASC']);
+        $organizations = $orgaRepository->findAllAsTree();
         return $this->render('organizations/index.html.twig', [
             'organizations' => $organizations,
         ]);

--- a/src/Controller/Tickets/MessagesController.php
+++ b/src/Controller/Tickets/MessagesController.php
@@ -10,6 +10,7 @@ use App\Controller\BaseController;
 use App\Entity\Message;
 use App\Entity\Ticket;
 use App\Repository\MessageRepository;
+use App\Repository\OrganizationRepository;
 use App\Repository\TicketRepository;
 use App\Utils\Time;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
@@ -25,6 +26,7 @@ class MessagesController extends BaseController
         Ticket $ticket,
         Request $request,
         MessageRepository $messageRepository,
+        OrganizationRepository $organizationRepository,
         TicketRepository $ticketRepository,
         ValidatorInterface $validator,
         HtmlSanitizerInterface $appMessageSanitizer
@@ -48,6 +50,10 @@ class MessagesController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
+        $organization = $ticket->getOrganization();
+        $parentOrganizations = $organizationRepository->findParents($organization);
+        $organization->setParentOrganizations($parentOrganizations);
+
         $statuses = Ticket::getStatusesWithLabels();
         if ($ticket->getStatus() !== 'new') {
             unset($statuses['new']);
@@ -57,7 +63,7 @@ class MessagesController extends BaseController
             return $this->renderBadRequest('tickets/show.html.twig', [
                 'ticket' => $ticket,
                 'messages' => $ticket->getMessages(),
-                'organization' => $ticket->getOrganization(),
+                'organization' => $organization,
                 'message' => $messageContent,
                 'status' => $status,
                 'statuses' => $statuses,
@@ -80,7 +86,7 @@ class MessagesController extends BaseController
             return $this->renderBadRequest('tickets/show.html.twig', [
                 'ticket' => $ticket,
                 'messages' => $ticket->getMessages(),
-                'organization' => $ticket->getOrganization(),
+                'organization' => $organization,
                 'message' => $messageContent,
                 'status' => $status,
                 'statuses' => $statuses,
@@ -113,7 +119,7 @@ class MessagesController extends BaseController
             return $this->renderBadRequest('tickets/show.html.twig', [
                 'ticket' => $ticket,
                 'messages' => $ticket->getMessages(),
-                'organization' => $ticket->getOrganization(),
+                'organization' => $organization,
                 'message' => $messageContent,
                 'status' => $status,
                 'statuses' => $statuses,

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -8,6 +8,7 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 use App\Entity\Ticket;
+use App\Repository\OrganizationRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -15,8 +16,12 @@ use Symfony\Component\Routing\Annotation\Route;
 class TicketsController extends BaseController
 {
     #[Route('/tickets/{uid}', name: 'ticket', methods: ['GET', 'HEAD'])]
-    public function show(Ticket $ticket): Response
+    public function show(Ticket $ticket, OrganizationRepository $organizationRepository): Response
     {
+        $organization = $ticket->getOrganization();
+        $parentOrganizations = $organizationRepository->findParents($organization);
+        $organization->setParentOrganizations($parentOrganizations);
+
         $statuses = Ticket::getStatusesWithLabels();
         if ($ticket->getStatus() !== 'new') {
             unset($statuses['new']);
@@ -25,7 +30,7 @@ class TicketsController extends BaseController
         return $this->render('tickets/show.html.twig', [
             'ticket' => $ticket,
             'messages' => $ticket->getMessages(),
-            'organization' => $ticket->getOrganization(),
+            'organization' => $organization,
             'message' => '',
             'status' => 'pending',
             'statuses' => $statuses,

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -61,6 +61,9 @@ class Organization
     /** @var Organization[] $subOrganizations */
     private array $subOrganizations = [];
 
+    /** @var Organization[] $parentOrganizations */
+    private array $parentOrganizations = [];
+
     public function __construct()
     {
         $this->tickets = new ArrayCollection();
@@ -131,12 +134,25 @@ class Organization
 
     public function getParentOrganizationId(): int|null
     {
-        if ($this->isRootOrganization()) {
+        $parentIds = $this->getParentOrganizationIds();
+        if (empty($parentIds)) {
             return null;
         }
 
+        return array_pop($parentIds);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getParentOrganizationIds(): array
+    {
+        if ($this->isRootOrganization()) {
+            return [];
+        }
+
         $ids = explode('/', trim($this->parentsPath, '/'));
-        return (int) array_pop($ids);
+        return array_map('intval', $ids);
     }
 
     public function getDepth(): int
@@ -157,5 +173,23 @@ class Organization
     public function getSubOrganizations(): array
     {
         return $this->subOrganizations;
+    }
+
+    /**
+     * @param Organization[] $parentOrganizations
+     */
+    public function setParentOrganizations(array $parentOrganizations): self
+    {
+        $this->parentOrganizations = $parentOrganizations;
+
+        return $this;
+    }
+
+    /**
+     * @return Organization[]
+     */
+    public function getParentOrganizations(): array
+    {
+        return $this->parentOrganizations;
     }
 }

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -18,10 +18,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OrganizationRepository::class)]
 #[UniqueEntity(
-    fields: 'name',
-    message: new TranslatableMessage('The name {{ value }} is already used.', [], 'validators'),
-)]
-#[UniqueEntity(
     fields: 'uid',
     message: new TranslatableMessage('The uid {{ value }} is already used.', [], 'validators'),
 )]
@@ -34,7 +30,7 @@ class Organization
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255, unique: true)]
+    #[ORM\Column(length: 255)]
     #[Assert\NotBlank(
         message: new TranslatableMessage('The name is required.', [], 'validators'),
     )]

--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -117,4 +117,13 @@ class OrganizationRepository extends ServiceEntityRepository
 
         return $rootOrganization;
     }
+
+    /**
+     * @return Organization[]
+     */
+    public function findParents(Organization $organization): array
+    {
+        $parentIds = $organization->getParentOrganizationIds();
+        return $this->findBy(['id' => $parentIds]);
+    }
 }

--- a/src/Service/OrganizationSorter.php
+++ b/src/Service/OrganizationSorter.php
@@ -1,0 +1,51 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Service;
+
+use App\Entity\Organization;
+use App\Utils\Locales;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class OrganizationSorter
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param Organization[] $organizations
+     */
+    public function sort(array &$organizations): void
+    {
+        $collator = new \Collator($this->getLocale());
+        uasort($organizations, function (Organization $o1, Organization $o2) use ($collator) {
+            $pathComparison = strcmp($o1->getParentsPath(), $o2->getParentsPath());
+            if ($pathComparison !== 0) {
+                return $pathComparison;
+            } else {
+                $nameComparison = $collator->compare($o1->getName(), $o2->getName());
+                if ($nameComparison === false) {
+                    $nameComparison = 0;
+                }
+                return $nameComparison;
+            }
+        });
+    }
+
+    private function getLocale(): string
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest) {
+            return $currentRequest->getLocale();
+        } else {
+            return Locales::DEFAULT_LOCALE;
+        }
+    }
+}

--- a/src/Validator/TreeDepth.php
+++ b/src/Validator/TreeDepth.php
@@ -1,0 +1,26 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class TreeDepth extends Constraint
+{
+    public string $message = 'The tree "{{ tree }}" is too deep (max is {{ max }} of depth).';
+
+    public int $max = 2;
+
+    #[HasNamedArguments]
+    public function __construct(string $message, int $max, array $groups = null, mixed $payload = null)
+    {
+        parent::__construct([], $groups, $payload);
+        $this->message = $message;
+        $this->max = $max;
+    }
+}

--- a/src/Validator/TreeDepthValidator.php
+++ b/src/Validator/TreeDepthValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Exception\ValidatorException;
+
+class TreeDepthValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof TreeDepth) {
+            throw new UnexpectedTypeException($constraint, TreeDepth::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!str_starts_with($value, '/')) {
+            throw new ValidatorException("Argument is expected to start with \"/\", \"{$value}\" given");
+        }
+
+        if (!str_ends_with($value, '/')) {
+            throw new ValidatorException("Argument is expected to end with \"/\", \"{$value}\" given");
+        }
+
+        $depth = substr_count($value, '/');
+
+        if ($depth > $constraint->max) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ tree }}', $value)
+                ->setParameter('{{ max }}', strval($constraint->max))
+                ->addViolation();
+        }
+    }
+}

--- a/templates/organizations/_organization_breadcrumb.html.twig
+++ b/templates/organizations/_organization_breadcrumb.html.twig
@@ -1,0 +1,19 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022-2023 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+ <div class="breadcrumb">
+     <ol class="breadcrumb__list">
+        {% for parentOrganization in organization.parentOrganizations %}
+            <li class="breadcrumb__item">
+                {{ parentOrganization.name }}
+            </li>
+        {% endfor %}
+
+        <li class="breadcrumb__item breadcrumb__item--active">
+            {{ organization.name }}
+        </li>
+     </ol>
+</div>

--- a/templates/organizations/_organizations_as_list.html.twig
+++ b/templates/organizations/_organizations_as_list.html.twig
@@ -1,0 +1,23 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022-2023 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+{% if organizations %}
+    <ul class="organizations__list">
+        {% for organization in organizations %}
+            <li class="organizations__list-item" data-test="organization-item">
+                <a href="{{ path('organization', { uid: organization.uid }) }}">
+                    {{ organization.name }}
+                </a>
+
+                {{ include(
+                    'organizations/_organizations_as_list.html.twig',
+                    { organizations: organization.subOrganizations },
+                    with_context = false
+                ) }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/templates/organizations/_organizations_as_options.html.twig
+++ b/templates/organizations/_organizations_as_options.html.twig
@@ -1,0 +1,20 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022-2023 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+{% for organization in organizations %}
+    <option value="{{ organization.uid }}" {{ organization.uid == selectedParentUid ? 'selected' }}>
+        {{ organization.name }}
+    </option>
+
+    {{ include(
+        'organizations/_organizations_as_options.html.twig',
+        {
+            organizations: organization.subOrganizations,
+            selectedParentUid: selectedParentUid,
+        },
+        with_context = false
+    ) }}
+{% endfor %}

--- a/templates/organizations/index.html.twig
+++ b/templates/organizations/index.html.twig
@@ -9,7 +9,7 @@
 {% block title %}{{ 'Organizations' | trans }}{% endblock %}
 
 {% block body %}
-    <main class="layout__body flow">
+    <main class="layout__body flow organizations-index">
         <h1>{{ 'Organizations' | trans }}</h1>
 
         <div class="wrapper-large wrapper--center flow">
@@ -27,6 +27,11 @@
                             </a>
 
                             <div class="card__body">
+                                {{ include(
+                                    'organizations/_organizations_as_list.html.twig',
+                                    { organizations: organization.subOrganizations },
+                                    with_context = false
+                                ) }}
                             </div>
 
                             <div class="text--center text--small">

--- a/templates/organizations/index.html.twig
+++ b/templates/organizations/index.html.twig
@@ -21,11 +21,21 @@
 
                 <div class="grid">
                     {% for organization in organizations %}
-                        <a class="card" href="{{ path('organization', { uid: organization.uid }) }}" data-test="organization-item">
-                            <div class="card__title">
+                        <div class="card flow" data-test="organization-item">
+                            <a class="card__title" href="{{ path('organization', { uid: organization.uid }) }}">
                                 {{ organization.name }}
+                            </a>
+
+                            <div class="card__body">
                             </div>
-                        </a>
+
+                            <div class="text--center text--small">
+                                <a href="{{ path('new organization', { parent: organization.uid }) }}">
+                                    {{ icon('plus') }}
+                                    {{ '<span class="sr-only">New</span> sub-organization' | trans | raw }}
+                                </a>
+                            </div>
+                        </div>
                     {% endfor %}
                 </div>
             {% else %}

--- a/templates/organizations/new.html.twig
+++ b/templates/organizations/new.html.twig
@@ -18,7 +18,7 @@
     <main class="layout__body flow">
         <h1>{{ 'New organization' | trans }}</h1>
 
-        <form action="{{ path('create organization') }}" method="post" class="wrapper-small wrapper--center flow">
+        <form action="{{ path('create organization', { parent: parentOrganization.uid ?? null }) }}" method="post" class="wrapper-small wrapper--center flow">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('create organization') }}">
 
             {% if error %}
@@ -54,6 +54,41 @@
                     {% endif %}
                 />
             </div>
+
+            {% if parentOrganization %}
+                <div class="flow-small" data-test="form-group-parent-organization">
+                    <label for="parent">
+                        {{ 'Parent organization' | trans }}
+                    </label>
+
+                    {% if errors.parentsPath is defined %}
+                        <p class="form__error" role="alert" id="parent-error">
+                            <span class="sr-only">{{ 'Error' | trans }}</span>
+                            {{ errors.parentsPath }}
+                        </p>
+                    {% endif %}
+
+                    <select
+                        id="parent"
+                        name="selectedParent"
+                        required
+                        {% if errors.parentsPath is defined %}
+                            autofocus
+                            aria-invalid="true"
+                            aria-errormessage="parent-error"
+                        {% endif %}
+                    >
+                        {{ include(
+                            'organizations/_organizations_as_options.html.twig',
+                            {
+                                organizations: [parentOrganization],
+                                selectedParentUid: selectedParentUid,
+                            },
+                            with_context = false
+                        ) }}
+                    </select>
+                </div>
+            {% endif %}
 
             <div class="form__actions">
                 <button id="form-create-organization-submit" class="button--primary" type="submit">

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -78,9 +78,11 @@
             <div class="flow row__item--extend">
                 <h1>{{ title }}</h1>
 
-                <div class="text--center">
-                    {{ organization.name }}
-                </div>
+                {{ include(
+                    'organizations/_organization_breadcrumb.html.twig',
+                    { organization: organization },
+                    with_context = false,
+                ) }}
 
                 {% if tickets %}
                     <div class="table-container">

--- a/templates/organizations/tickets/new.html.twig
+++ b/templates/organizations/tickets/new.html.twig
@@ -18,9 +18,11 @@
     <main class="layout__body flow">
         <h1>{{ 'New ticket' | trans }}</h1>
 
-        <div class="text--center">
-            {{ organization.name }}
-        </div>
+        {{ include(
+            'organizations/_organization_breadcrumb.html.twig',
+            { organization: organization },
+            with_context = false,
+        ) }}
 
         <form
             action="{{ path('create organization ticket', {'uid': organization.uid}) }}"

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -22,9 +22,11 @@
                 <span class="ticket__id">#{{ ticket.id }}</span>
             </h1>
 
-            <div class="text--center">
-                {{ organization.name }}
-            </div>
+            {{ include(
+                'organizations/_organization_breadcrumb.html.twig',
+                { organization: organization },
+                with_context = false,
+            ) }}
 
             <div class="text--center">
                 <span class="ticket__status badge badge--bold badge--{{ ticket.statusBadgeColor }}" title="{{ 'Status' | trans }}">{{ icon('status') }} {{ ticket.statusLabel | trans }}</span>

--- a/tests/Controller/OrganizationsControllerTest.php
+++ b/tests/Controller/OrganizationsControllerTest.php
@@ -196,25 +196,6 @@ class OrganizationsControllerTest extends WebTestCase
         $this->assertSame(0, OrganizationFactory::count());
     }
 
-    public function testPostCreateFailsIfNameAlreadyExists(): void
-    {
-        $client = static::createClient();
-        $user = UserFactory::createOne();
-        $client->loginUser($user->object());
-        $name = 'My organization';
-        OrganizationFactory::createOne([
-            'name' => $name,
-        ]);
-
-        $client->request('POST', '/organizations/new', [
-            '_csrf_token' => $this->generateCsrfToken($client, 'create organization'),
-            'name' => $name,
-        ]);
-
-        $this->assertSelectorTextContains('#name-error', 'The name "My organization" is already used.');
-        $this->assertSame(1, OrganizationFactory::count());
-    }
-
     public function testPostCreateFailsIfNameIsTooLong(): void
     {
         $client = static::createClient();

--- a/tests/Controller/OrganizationsControllerTest.php
+++ b/tests/Controller/OrganizationsControllerTest.php
@@ -40,6 +40,40 @@ class OrganizationsControllerTest extends WebTestCase
         $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(2)', 'My organization 2');
     }
 
+    public function testGetIndexListsSubOrganizations(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $organization = OrganizationFactory::createOne([
+            'name' => 'My organization',
+        ]);
+        $subOrganization = OrganizationFactory::createOne([
+            'name' => 'My sub-organization',
+            'parentsPath' => "/{$organization->getId()}/",
+        ]);
+        $subSubOrganization = OrganizationFactory::createOne([
+            'name' => 'My sub-sub-organization',
+            'parentsPath' => "/{$organization->getId()}/{$subOrganization->getId()}/",
+        ]);
+
+        $client->request('GET', '/organizations');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains(
+            '[data-test="organization-item"]',
+            'My organization',
+        );
+        $this->assertSelectorTextContains(
+            '[data-test="organization-item"] [data-test="organization-item"]',
+            'My sub-organization',
+        );
+        $this->assertSelectorTextContains(
+            '[data-test="organization-item"] [data-test="organization-item"] [data-test="organization-item"]',
+            'My sub-sub-organization',
+        );
+    }
+
     public function testGetIndexDisplaysAPlaceholderIfNoOrganization(): void
     {
         $client = static::createClient();

--- a/tests/Controller/OrganizationsControllerTest.php
+++ b/tests/Controller/OrganizationsControllerTest.php
@@ -26,18 +26,26 @@ class OrganizationsControllerTest extends WebTestCase
         $user = UserFactory::createOne();
         $client->loginUser($user->object());
         OrganizationFactory::createOne([
-            'name' => 'My organization 2',
+            'name' => 'foo',
         ]);
         OrganizationFactory::createOne([
-            'name' => 'My organization 1',
+            'name' => 'Foo',
+        ]);
+        OrganizationFactory::createOne([
+            'name' => 'bar',
+        ]);
+        OrganizationFactory::createOne([
+            'name' => 'Bar',
         ]);
 
         $client->request('GET', '/organizations');
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Organizations');
-        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(1)', 'My organization 1');
-        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(2)', 'My organization 2');
+        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(1)', 'bar');
+        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(2)', 'Bar');
+        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(3)', 'foo');
+        $this->assertSelectorTextContains('[data-test="organization-item"]:nth-child(4)', 'Foo');
     }
 
     public function testGetIndexListsSubOrganizations(): void

--- a/tests/Factory/OrganizationFactory.php
+++ b/tests/Factory/OrganizationFactory.php
@@ -57,6 +57,7 @@ final class OrganizationFactory extends ModelFactory
         return [
             'name' => self::faker()->text(),
             'uid' => Random::hex(20),
+            'parentsPath' => '/',
         ];
     }
 

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -102,3 +102,5 @@ Name: Name
 'Current password': 'Current password'
 'New password': 'New password'
 'Show password as plain text. Note: this will visually expose your password.': 'Show password as plain text. Note: this will visually expose your password.'
+'Parent organization': 'Parent organization'
+'<span class="sr-only">New</span> sub-organization': '<span class="sr-only">New</span> sub-organization'

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -102,3 +102,5 @@ Name: Nom
 'Current password': 'Mot de passe actuel'
 'New password': 'Nouveau mot de passe'
 'Show password as plain text. Note: this will visually expose your password.': 'Afficher le mot de passe sous forme de texte. Attention, cela exposera votre mot de passe visuellement.'
+'Parent organization': 'Organisation parente'
+'<span class="sr-only">New</span> sub-organization': '<span class="sr-only">Nouvelle</span> sous-organisation'

--- a/translations/validators.en_GB.yaml
+++ b/translations/validators.en_GB.yaml
@@ -118,3 +118,5 @@ Error: Error
 'The priority {{ value }} is not a valid priority.': 'The priority {{ value }} is not a valid priority.'
 'The via {{ value }} is not a valid via.': 'The via {{ value }} is not a valid via.'
 'The message is required.': 'The message is required.'
+'The sub-organization cannot be attached to this organization.': 'The sub-organization cannot be attached to this organization.'
+'Select an organization from this list.': 'Select an organization from this list.'

--- a/translations/validators.fr_FR.yaml
+++ b/translations/validators.fr_FR.yaml
@@ -118,3 +118,5 @@ Error: Erreur
 'The priority {{ value }} is not a valid priority.': 'La priorité {{ value }} n’est pas une priorité valide.'
 'The via {{ value }} is not a valid via.': 'Le via {{ value }} n’est pas un via valide.'
 'The message is required.': 'Le message est obligatoire.'
+'The sub-organization cannot be attached to this organization.': 'La sous-organisation ne peut être attachée à cette organisation.'
+'Select an organization from this list.': 'Sélectionnez une organisation depuis cette liste.'


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/87

Changes proposed in this pull request:

- Add a parentsPath field to Organization entity which contains the list of parents organizations ids
- parentsPath is configured with a max depth of 3
- Add a link to the "new organization" page in the organizations cards
- In this case, a new select box is displayed to allow to select a parent organization
- Display the sub-organizations in the organizations cards
- Sort the organizations in code instead of SQL (so we handle locale-specific cases)
- Remove unique constraint on organization name (to handle the cases where two different organizations have sub-organizations with the same name)
- Display the list of organizations parents in the interface (e.g. when displaying a ticket)

How to test the feature manually:

1. create an organization, then click on "+ sub-organization"
2. create a sub-organization under the first organization
3. verify it appears on the home page in the organization card
4. create a sub-sub-organization (by attaching it to the sub-organization)
5. verify it appears on the home page in the organization card
6. verify you cannot create a sub-sub-sub-organization
7. verify you can (still) create tickets in the different organizations
8. verify the full "organizations path" appears when listing, creating or showing a ticket

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
