### PR TITLE
imp: Improve sizes on mobile

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -57,7 +57,7 @@ body {
         Cantarell,
         "Helvetica Neue",
         sans-serif;
-    font-size: 18px;
+    font-size: 20px;
 
     background: var(--color-grey2);
 }

--- a/assets/stylesheets/components/popups.css
+++ b/assets/stylesheets/components/popups.css
@@ -121,7 +121,7 @@
 .popup__item {
     display: block;
     width: 100%;
-    padding: 0.75rem 1.5rem;
+    padding: 1rem 1.5rem;
 
     color: var(--color-grey12);
     line-height: 1.5;


### PR DESCRIPTION
Changes proposed in this pull request:

- Increase font-size on mobile
- Increase padding of popups on mobile

How to test the feature manually:

1. verify it looks bigger!

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
