### PR TITLE
tec: Extract a LocaleSorter from OrganizationSorter

### DIFF
--- a/src/Service/LocaleSorter.php
+++ b/src/Service/LocaleSorter.php
@@ -1,0 +1,30 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Service;
+
+use App\Utils\Locales;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LocaleSorter
+{
+    private RequestStack $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    protected function getLocale(): string
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest) {
+            return $currentRequest->getLocale();
+        } else {
+            return Locales::DEFAULT_LOCALE;
+        }
+    }
+}

--- a/src/Service/OrganizationSorter.php
+++ b/src/Service/OrganizationSorter.php
@@ -7,18 +7,9 @@
 namespace App\Service;
 
 use App\Entity\Organization;
-use App\Utils\Locales;
-use Symfony\Component\HttpFoundation\RequestStack;
 
-class OrganizationSorter
+class OrganizationSorter extends LocaleSorter
 {
-    private RequestStack $requestStack;
-
-    public function __construct(RequestStack $requestStack)
-    {
-        $this->requestStack = $requestStack;
-    }
-
     /**
      * @param Organization[] $organizations
      */
@@ -37,15 +28,5 @@ class OrganizationSorter
                 return $nameComparison;
             }
         });
-    }
-
-    private function getLocale(): string
-    {
-        $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest) {
-            return $currentRequest->getLocale();
-        } else {
-            return Locales::DEFAULT_LOCALE;
-        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Extract a LocaleSorter from OrganizationSorter

How to test the feature manually: N/A

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated N/A
- [x] French locale is synchronized N/A
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
