### PR TITLE
tec: Rename the admin:see:settings permission

### DIFF
--- a/docs/developers/roles.md
+++ b/docs/developers/roles.md
@@ -14,7 +14,7 @@ Authorizations associated to an admin role are never associated to an organizati
 
 Permissions examples:
 
-- access to the global "setting" (always applied): `admin:see:settings`
+- access to the global settings (always applied): `admin:see`
     - manage the roles: `admin:manage:roles`
     - manage the users: `admin:manage:users`
     - manage the organizations: `admin:manage:organizations`

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -79,8 +79,8 @@ class RolesController extends BaseController
             $type = 'orga';
         }
 
-        if ($type === 'admin' && !in_array('admin:see:settings', $permissions)) {
-            $permissions[] = 'admin:see:settings';
+        if ($type === 'admin' && !in_array('admin:see', $permissions)) {
+            $permissions[] = 'admin:see';
         }
 
         $permissions = Role::sanitizePermissions($type, $permissions);

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -30,7 +30,7 @@ class Role
 
     public const PERMISSIONS = [
         'admin:*',
-        'admin:see:settings',
+        'admin:see',
     ];
 
     #[ORM\Id]

--- a/tests/Controller/RolesControllerTest.php
+++ b/tests/Controller/RolesControllerTest.php
@@ -136,7 +136,7 @@ class RolesControllerTest extends WebTestCase
         $role = RoleFactory::last();
         $this->assertSame('admin', $role->getType());
         // This permission is always set for admin roles
-        $this->assertSame(['admin:see:settings'], $role->getPermissions());
+        $this->assertSame(['admin:see'], $role->getPermissions());
     }
 
     public function testPostCreateCannotCreateSuperRole(): void
@@ -186,7 +186,7 @@ class RolesControllerTest extends WebTestCase
         $description = 'What it does';
         $permissions = [
             'admin:*',
-            'admin:see:settings',
+            'admin:see',
             'orga:foo',
             'foo:bar',
         ];
@@ -212,7 +212,7 @@ class RolesControllerTest extends WebTestCase
         $description = 'What it does';
         $permissions = [
             'admin:*',
-            'admin:see:settings',
+            'admin:see',
             'orga:foo',
             'foo:bar',
         ];
@@ -226,7 +226,7 @@ class RolesControllerTest extends WebTestCase
 
         $this->assertResponseRedirects('/roles', 302);
         $role = RoleFactory::last();
-        $this->assertSame(['admin:see:settings'], $role->getPermissions());
+        $this->assertSame(['admin:see'], $role->getPermissions());
     }
 
     public function testPostCreateFailsIfNameIsEmpty(): void


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/88

Changes proposed in this pull request:

- Rename the permission `admin:see:settings` in `admin:see`

How to test the feature manually: N/A

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] copyright notice is updated N/A
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
