### PR TITLE
new: Add a home page to list assigned tickets

### DIFF
--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -6,6 +6,7 @@
 
 namespace App\Controller;
 
+use App\Service\TicketSearcher;
 use App\Utils\Locales;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -13,9 +14,16 @@ use Symfony\Component\Routing\Annotation\Route;
 class PagesController extends BaseController
 {
     #[Route('/', name: 'home', methods: ['GET', 'HEAD'])]
-    public function home(): Response
+    public function home(TicketSearcher $ticketSearcher): Response
     {
-        return $this->redirectToRoute('organizations');
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+        $ticketSearcher->setAssignee($user);
+        $tickets = $ticketSearcher->getTickets();
+
+        return $this->render('pages/home.html.twig', [
+            'tickets' => $tickets,
+        ]);
     }
 
     #[Route('/about', name: 'about', methods: ['GET', 'HEAD'])]

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -124,7 +124,7 @@
                             </thead>
 
                             <tbody>
-                                {% for ticket in tickets|sort((a, b) => b.createdAt <=> a.createdAt) %}
+                                {% for ticket in tickets %}
                                     <tr data-test="ticket-item">
                                         <td>
                                             <time datetime="{{ ticket.createdAt | dateIso }}" class="text--small">

--- a/templates/pages/home.html.twig
+++ b/templates/pages/home.html.twig
@@ -1,0 +1,101 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022-2023 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'Welcome to Bileto' | trans }}{% endblock %}
+
+{% block body %}
+    <main class="layout__body flow organizations-index">
+        <h1>{{ 'Welcome to Bileto' | trans }}</h1>
+
+        <div class="wrapper-large wrapper--center flow-larger">
+            {% if tickets %}
+                <div class="flow">
+                    <h2>{{ 'Your tickets' | trans }}</h2>
+
+                    <div class="table-container">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th class="col--size4">
+                                        {{ 'Opened on' | trans }}
+                                    </th>
+
+                                    <th>
+                                        {{ 'Title' | trans }}
+                                    </th>
+
+                                    <th class="col--size2">
+                                        {{ 'Type' | trans }}
+                                    </th>
+
+                                    <th class="col--size5">
+                                        {{ icon('user') }}
+                                        {{ 'Requester' | trans }}
+                                    </th>
+
+                                    <th class="col--size3 text--center">
+                                        {{ icon('status') }}
+                                        {{ 'Status' | trans }}
+                                    </th>
+
+                                    <th class="col--size3 text--center">
+                                        {{ icon('priority') }}
+                                        {{ 'Priority' | trans }}
+                                    </th>
+                                </tr>
+                            </thead>
+
+                            <tbody>
+                                {% for ticket in tickets %}
+                                    <tr data-test="ticket-item">
+                                        <td>
+                                            <time datetime="{{ ticket.createdAt | dateIso }}" class="text--small">
+                                                {{ ticket.createdAt | dateTrans }}
+                                            </time>
+                                        </td>
+
+                                        <td class="td--anchor">
+                                            <a href="{{ path('ticket', {'uid': ticket.uid}) }}">
+                                                <span class="ticket__title">{{ ticket.title }}</span>
+                                                <span class="ticket__id">#{{ ticket.id }}</span>
+                                            </a>
+                                        </td>
+
+                                        <td>
+                                            {% if ticket.type == 'incident' %}
+                                                {{ 'Incident' | trans }}
+                                            {% else %}
+                                                {{ 'Request' | trans }}
+                                            {% endif %}
+                                        </td>
+
+                                        <td>
+                                            {{ ticket.requester.displayName }}
+                                        </td>
+
+                                        <td class="text--center">
+                                            <span class="badge badge--{{ ticket.statusBadgeColor }}">
+                                                {{ ticket.statusLabel | trans }}
+                                            </span>
+                                        </td>
+
+                                        <td class="text--center">
+                                            <span class="badge badge--{{ ticket.priorityBadgeColor }}">
+                                                {{ ticket.priorityLabel | trans }}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </main>
+{% endblock %}

--- a/tests/Controller/PagesControllerTest.php
+++ b/tests/Controller/PagesControllerTest.php
@@ -16,7 +16,7 @@ class PagesControllerTest extends WebTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testGetHomeRedirectsToOrganizationsIfConnected(): void
+    public function testGetHomeRendersCorrectly(): void
     {
         $client = static::createClient();
         $user = UserFactory::createOne();
@@ -24,7 +24,7 @@ class PagesControllerTest extends WebTestCase
 
         $crawler = $client->request('GET', '/');
 
-        $this->assertResponseRedirects('/organizations', 302);
+        $this->assertSelectorTextContains('h1', 'Welcome to Bileto');
     }
 
     public function testGetHomeRedirectsToLoginIfNotConnected(): void

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -120,3 +120,5 @@ Description: Description
 Permissions: Permissions
 'No permissions are available for now.': 'No permissions are available for now.'
 'Create the role': 'Create the role'
+'Welcome to Bileto': 'Welcome to Bileto'
+'Your tickets': 'Your tickets'

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -120,3 +120,5 @@ Description: Description
 Permissions: Permissions
 'No permissions are available for now.': 'Aucune permission disponible pour l’instant.'
 'Create the role': 'Créer le rôle'
+'Welcome to Bileto': 'Bienvenue sur Bileto'
+'Your tickets': 'Vos tickets'


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove the useless sort when listing tickets
- Get the assigned tickets and display them on the home page

How to test the feature manually:

1. Assign some tickets to your user
2. Go to the home page
3. Check the tickets are shown on the home page

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
