### PR TITLE
new: Revoke users authorizations

### DIFF
--- a/templates/users/authorizations/index.html.twig
+++ b/templates/users/authorizations/index.html.twig
@@ -30,7 +30,7 @@
                     </a>
 
                     {% for authorization in authorizations %}
-                        <div class="card" data-test="authorization-item">
+                        <div class="card flow" data-test="authorization-item">
                             <div class="card__title">
                                 {% if authorization.role.type == 'super' %}
                                     {{ icon('crown') }}
@@ -61,6 +61,28 @@
                                     </div>
                                 {% endif %}
                             </div>
+
+                            {% if (
+                                authorization.role.type == 'super' and (
+                                    not is_granted('admin:*') or
+                                    app.user.id == authorization.holder.id
+                                )
+                            ) %}
+                                <p class="text--secondary text--center text--small">
+                                    {{ 'users.authorizations.index.revoke.disabled' | trans }}
+                                </p>
+                            {% else %}
+                                <form
+                                    class="text--center"
+                                    method="post"
+                                    action="{{ path('delete user authorization', { uid: authorization.uid }) }}"
+                                >
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('delete user authorization') }}">
+                                    <button type="submit" data-turbo-confirm="{{ 'users.authorizations.index.revoke.confirm' | trans }}">
+                                        {{ 'users.authorizations.index.revoke' | trans }}
+                                    </button>
+                                </form>
+                            {% endif %}
                         </div>
                     {% endfor %}
                 </div>

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -126,6 +126,9 @@ users.color_scheme.dark: Dark
 users.email: 'Email address'
 users.authorizations.index.new_authorization: 'Give an authorization'
 users.authorizations.index.no_authorizations: 'No authorizations'
+users.authorizations.index.revoke: Revoke
+users.authorizations.index.revoke.confirm: 'Are you sure that you want to revoke this authorization?'
+users.authorizations.index.revoke.disabled: 'You can’t revoke this authorization.'
 users.authorizations.index.title: 'Authorizations ({name})'
 users.authorizations.new.global: Global
 users.authorizations.new.organization: 'Choose an organization'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -126,6 +126,9 @@ users.color_scheme.dark: Sombre
 users.email: 'Adresse email'
 users.authorizations.index.new_authorization: 'Donner une autorisation'
 users.authorizations.index.no_authorizations: 'Aucune autorisation'
+users.authorizations.index.revoke: Révoquer
+users.authorizations.index.revoke.confirm: "Êtes-vous sûr de vouloir révoquer cette autorisation\_?"
+users.authorizations.index.revoke.disabled: 'Vous ne pouvez pas révoquer cette autorisation.'
 users.authorizations.index.title: 'Autorisations ({name})'
 users.authorizations.new.global: Global
 users.authorizations.new.organization: 'Choisir une organisation'

--- a/translations/validators+intl-icu.en_GB.yaml
+++ b/translations/validators+intl-icu.en_GB.yaml
@@ -130,3 +130,4 @@ Error: Error
 'This user already has an admin role.': 'This user already has an admin role.'
 'This user already has an orga role for this organization.': 'This user already has an orga role for this organization.'
 'You can’t grant super-admin authorization.': 'You can’t grant super-admin authorization.'
+'You can’t revoke this authorization.': 'You can’t revoke this authorization.'

--- a/translations/validators+intl-icu.fr_FR.yaml
+++ b/translations/validators+intl-icu.fr_FR.yaml
@@ -130,3 +130,4 @@ Error: Erreur
 'This user already has an admin role.': 'Cet utilisateur possède déjà un rôle admin.'
 'This user already has an orga role for this organization.': 'Cet utilisateur possède déjà un rôle orga pour cette organisation.'
 'You can’t grant super-admin authorization.': 'Vous ne pouvez pas accorder de droit super-admin.'
+'You can’t revoke this authorization.': 'Vous ne pouvez pas révoquer cette autorisation.'


### PR DESCRIPTION
Related to https://github.com/Probesys/bileto/issues/88

Changes proposed in this pull request:

- Add an endpoint to revoke the authorizations
- Add a button to revoke the authorizations in the list

How to test the feature manually:

1. Go to the authorizations list of a user, revoke an authorization → check it works
2. With super-admin authorization, go to your own authorization list → check the revoke button is hidden
3. With only `admin:manage:users` permission, go to the authorization list of a super-admin user → check the revoke button is hidden

Pull request checklist:

- [x] code is manually tested
- [x] authorizations are checked
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] locales are synchronized
- [x] copyright notice is updated
- [x] documentation is updated (including comments, commit messages, migration notes…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
