### PR TITLE
new: Allow to hide history in tickets timelines

### DIFF
--- a/assets/stylesheets/components/timelines.css
+++ b/assets/stylesheets/components/timelines.css
@@ -50,3 +50,17 @@
     font-style: italic;
     text-align: center;
 }
+
+.timeline__events-visibility {
+    position: relative;
+
+    margin-left: 5.25rem;
+
+    font-size: 0.8em;
+}
+
+@media (min-width: 800px) {
+    .timeline__events-visibility {
+        margin-left: 7.25rem;
+    }
+}

--- a/migrations/Version20230227142951AddHideEventsToUser.php
+++ b/migrations/Version20230227142951AddHideEventsToUser.php
@@ -1,0 +1,40 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230227142951AddHideEventsToUser extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the hide_events column to the users table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform()->getName();
+        if ($dbPlatform === 'postgresql') {
+            $this->addSql('ALTER TABLE users ADD hide_events BOOLEAN NOT NULL');
+        } elseif ($dbPlatform === 'mysql') {
+            $this->addSql('ALTER TABLE users ADD hide_events TINYINT(1) NOT NULL');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform()->getName();
+        if ($dbPlatform === 'postgresql') {
+            $this->addSql('ALTER TABLE "users" DROP hide_events');
+        } elseif ($dbPlatform === 'mysql') {
+            $this->addSql('ALTER TABLE `users` DROP hide_events');
+        }
+    }
+}

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -8,6 +8,7 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
@@ -50,5 +51,19 @@ class BaseController extends AbstractController
             }
         }
         return $formattedErrors;
+    }
+
+    protected function isPathRedirectable(string $path): bool
+    {
+        $router = $this->container->get('router');
+
+        try {
+            $router->match($path);
+            return true;
+        } catch (MethodNotAllowedException $e) {
+            return in_array('GET', $e->getAllowedMethods());
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -96,6 +96,9 @@ class User implements
     #[ORM\OneToMany(mappedBy: 'holder', targetEntity: Authorization::class, orphanRemoval: true)]
     private Collection $authorizations;
 
+    #[ORM\Column]
+    private ?bool $hideEvents = false;
+
     public function __construct()
     {
         $this->authorizations = new ArrayCollection();
@@ -250,5 +253,17 @@ class User implements
     public function getAuthorizations(): Collection
     {
         return $this->authorizations;
+    }
+
+    public function areEventsHidden(): ?bool
+    {
+        return $this->hideEvents;
+    }
+
+    public function setHideEvents(bool $hideEvents): self
+    {
+        $this->hideEvents = $hideEvents;
+
+        return $this;
     }
 }

--- a/src/Service/TicketTimeline.php
+++ b/src/Service/TicketTimeline.php
@@ -40,14 +40,19 @@ class TicketTimeline
             $messages = $ticket->getMessagesWithoutConfidential()->toArray();
         }
 
-        $events = $this->entityEventRepository->findBy([
-            'entityType' => Ticket::class,
-            'entityId' => $ticket->getId(),
-            'type' => 'update',
-        ]);
-
         $timeline->addItems($messages);
-        $timeline->addItems($events);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->security->getUser();
+        if (!$user->areEventsHidden()) {
+            $events = $this->entityEventRepository->findBy([
+                'entityType' => Ticket::class,
+                'entityId' => $ticket->getId(),
+                'type' => 'update',
+            ]);
+
+            $timeline->addItems($events);
+        }
 
         return $timeline;
     }

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -72,6 +72,28 @@
                             {{ include('tickets/_timeline_event.html.twig', { event: timelineItem }) }}
                         {% endif %}
                     {% endfor %}
+
+                    <form
+                        class="timeline__events-visibility"
+                        method="post"
+                        action="{{ path('update hide events') }}"
+                        data-turbo-preserve-scroll
+                    >
+                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('update hide events') }}">
+                        <input type="hidden" name="from" value="{{ path('ticket', { uid: ticket.uid }) }}">
+
+                        {% if app.user.areEventsHidden %}
+                            <button name="hideEvents" value="false">
+                                {{ icon('eye') }}
+                                {{ 'tickets.show.show_history' | trans }}
+                            </button>
+                        {% else %}
+                            <button name="hideEvents" value="true">
+                                {{ icon('eye-slash') }}
+                                {{ 'tickets.show.hide_history' | trans }}
+                            </button>
+                        {% endif %}
+                    </form>
                 </div>
 
                 {% if is_granted('orga:create:tickets:messages', organization) %}

--- a/tests/Controller/PreferencesControllerTest.php
+++ b/tests/Controller/PreferencesControllerTest.php
@@ -139,4 +139,25 @@ class PreferencesControllerTest extends WebTestCase
         $this->assertSame($initialColorScheme, $user->getColorScheme());
         $this->assertSame($initialLocale, $user->getLocale());
     }
+
+    public function testPostUpdateHideEventsSavesTheUserAndRedirects(): void
+    {
+        $client = static::createClient();
+        $initialHideEvents = false;
+        $newHideEvents = true;
+        $user = UserFactory::createOne([
+            'hideEvents' => $initialHideEvents,
+        ]);
+        $client->loginUser($user->object());
+
+        $client->request('POST', '/preferences/hide-events', [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update hide events'),
+            'hideEvents' => $newHideEvents,
+            'from' => '/preferences',
+        ]);
+
+        $this->assertResponseRedirects('/preferences', 302);
+        $user->refresh();
+        $this->assertSame($newHideEvents, $user->areEventsHidden());
+    }
 }

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -120,6 +120,7 @@ tickets.show.actions.turn_into_request: 'Turn into a request'
 tickets.show.answer: Answer
 tickets.show.assign_yourself: 'assign yourself'
 tickets.show.closed: 'This ticket is closed.'
+tickets.show.hide_history: 'Hide history'
 tickets.show.impact: 'Impact:'
 tickets.show.mark_as: 'Mark as…'
 tickets.show.mark_as.confidential: confidential
@@ -131,6 +132,7 @@ tickets.show.opened_incident: 'opened this <strong>incident</strong>'
 tickets.show.opened_on: 'on {date}'
 tickets.show.opened_request: 'opened this <strong>request</strong>'
 tickets.show.resolved: 'This ticket is resolved.'
+tickets.show.show_history: 'Show history'
 tickets.show.status_to: 'Status to'
 tickets.show.urgency: 'Urgency:'
 tickets.status: Status

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -120,6 +120,7 @@ tickets.show.actions.turn_into_request: 'Changer en demande'
 tickets.show.answer: Répondre
 tickets.show.assign_yourself: attribuez-vous
 tickets.show.closed: 'Ce ticket est clos.'
+tickets.show.hide_history: 'Masquer l’historique'
 tickets.show.impact: "Impact\_:"
 tickets.show.mark_as: 'Marquer comme…'
 tickets.show.mark_as.confidential: confidentiel
@@ -131,6 +132,7 @@ tickets.show.opened_incident: 'a ouvert cet <strong>incident</strong>'
 tickets.show.opened_on: 'le {date}'
 tickets.show.opened_request: 'a ouvert cette <strong>demande</strong>'
 tickets.show.resolved: 'Ce ticket est résolu.'
+tickets.show.show_history: 'Afficher l’historique'
 tickets.show.status_to: 'Statut vers'
 tickets.show.urgency: "Urgence\_:"
 tickets.status: Statut


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/13

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add a new `hideEvents` property to User entity
- add a new endpoint in Preferences controller to change `hideEvents`
- to allow to redirect to an arbitrary page (i.e. any ticket page), this new endpoint takes a `from` parameter. This from is protected with a new `isPathRedirectable` added to the Base controller
- don't load the events in the TicketTimeline service if `hideEvents` is false
- add a button to toggle `hideEvents` at the bottom of the tickets timelines
    - I've added it at the end to avoid to clutter the top of the page
    - the drawback is that one has to scroll to the end of the page to hide all the events. If there are a lot of events, it can became annoying

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- go to a ticket and make sure there are events
- click on "Hide history" → check events are hidden
- click on "Show history" → check they appear

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
