### PR TITLE
misc: Don't track the dev_assets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
 /public/dev_assets/*
-!/public/dev_assets/.keep
 /public/manifest.dev.json
 /var/
 /vendor/

--- a/.vite/empty-assets-dir-plugin.js
+++ b/.vite/empty-assets-dir-plugin.js
@@ -17,18 +17,18 @@ export default function emptyAssetsDirPlugin () {
         },
 
         buildStart (options) {
-            fs.readdir(assetsFullDir, (err, filenames) => {
-                if (err) throw err;
+            fs.access(assetsFullDir, fs.constants.F_OK, (err) => {
+                if (err) return;
 
-                for (const filename of filenames) {
-                    if (filename === '.keep') {
-                        continue;
+                fs.readdir(assetsFullDir, (err, filenames) => {
+                    if (err) throw err;
+
+                    for (const filename of filenames) {
+                        fs.unlink(path.join(assetsFullDir, filename), (err) => {
+                            if (err) throw err;
+                        });
                     }
-
-                    fs.unlink(path.join(assetsFullDir, filename), (err) => {
-                        if (err) throw err;
-                    });
-                }
+                });
             });
         },
     };


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/234

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- remove the file `public/dev_assets/.keep`
- adapt the Vite plugin `empty-assets-dir` so it doesn't fail if the folder doesn't exist

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

N/A

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
