### PR TITLE
tec: Apply .flow* classes to rows correctly

### DIFF
--- a/assets/stylesheets/components/timelines.css
+++ b/assets/stylesheets/components/timelines.css
@@ -5,7 +5,7 @@
 .timeline {
     position: relative;
 
-    padding-bottom: 3rem;
+    padding-bottom: 4rem;
 
     border-bottom: 0.3rem solid var(--color-grey6);
 }

--- a/assets/stylesheets/pages/tickets-show.css
+++ b/assets/stylesheets/pages/tickets-show.css
@@ -19,23 +19,15 @@
     font-size: 0.9em;
 }
 
-@media (max-width: 799px) {
-    .tickets-show .ticket__info {
-        margin-top: 5rem;
-    }
-}
-
 @media (min-width: 800px) {
     .tickets-show .ticket__info {
         width: 250px;
-        margin-left: 2rem;
     }
 }
 
 @media (min-width: 1200px) {
     .tickets-show .ticket__info {
         width: 350px;
-        margin-left: 5rem;
     }
 }
 

--- a/assets/stylesheets/utils/flow.css
+++ b/assets/stylesheets/utils/flow.css
@@ -2,22 +2,50 @@
 /* Copyright 2022-2023 Probesys */
 /* SPDX-License-Identifier: AGPL-3.0-or-later */
 
-.flow-smaller > * + * {
-    margin-top: 0.5rem;
+.flow-smaller > * {
+    --flow-size: 0.5rem;
 }
 
-.flow-small > * + * {
-    margin-top: 1rem;
+.flow-small > * {
+    --flow-size: 1rem;
 }
 
-.flow > * + * {
-    margin-top: 2rem;
+.flow > * {
+    --flow-size: 2rem;
 }
 
-.flow-large > * + * {
-    margin-top: 3rem;
+.flow-large > * {
+    --flow-size: 3rem;
 }
 
+.flow-larger > * {
+    --flow-size: 4rem;
+}
+
+.flow-smaller > * + *,
+.flow-small > * + *,
+.flow > * + *,
+.flow-large > * + *,
 .flow-larger > * + * {
-    margin-top: 4rem;
+    margin-top: var(--flow-size);
+}
+
+.flow-smaller.row--always > * + *,
+.flow-small.row--always > * + *,
+.flow.row--always > * + *,
+.flow-large.row--always > * + *,
+.flow-larger.row--always > * + * {
+    margin-top: 0;
+    margin-left: var(--flow-size);
+}
+
+@media (min-width: 800px) {
+    .flow-smaller.row > * + *,
+    .flow-small.row > * + *,
+    .flow.row > * + *,
+    .flow-large.row > * + *,
+    .flow-larger.row > * + * {
+        margin-top: 0;
+        margin-left: var(--flow-size);
+    }
 }

--- a/assets/stylesheets/utils/rows.css
+++ b/assets/stylesheets/utils/rows.css
@@ -18,17 +18,6 @@
     align-items: center;
 }
 
-.row > * + * {
-    margin-left: 2rem;
-}
-
-@media (max-width: 799px) {
-    .row:not(.row--always) > * + * {
-        margin-top: 2rem;
-        margin-left: 0;
-    }
-}
-
 .row__item--extend {
     flex: 1;
 }

--- a/docs/developers/rows-and-grids.md
+++ b/docs/developers/rows-and-grids.md
@@ -40,6 +40,15 @@ If you need to center the items, use `.row--center`:
 </div>
 ```
 
+To add space between row items, just use one of the `.flow*` classes:
+
+```html
+<div class="row flow">
+    <div>Item 1</div>
+    <div>Item 2</div>
+</div>
+```
+
 You can tell a row item to take all the remaining space with `.row__item--extend`:
 
 ```html

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -57,7 +57,7 @@
             {% for label, messages in app.flashes(['success', 'error']) %}
                 {% for key, message in messages %}
                     <div
-                        class="notifications__item notifications__item--{{ label }} row row--center"
+                        class="notifications__item notifications__item--{{ label }} row row--center flow"
                         {% if label == "error" %}
                             role="alert"
                             aria-live="assertive"
@@ -173,7 +173,7 @@
                 </div>
             </nav>
 
-            <div class="row">
+            <div class="row flow">
                 {% block sidebar %}{% endblock %}
 
                 <div id="main-content" class="row__item--extend">

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -23,7 +23,7 @@
             <h1>{{ title }}</h1>
         </div>
 
-        <div class="row">
+        <div class="row flow">
             {% if is_granted('orga:see:tickets:all', organization) %}
                 <nav class="tickets__nav row__item--noshrink card flow">
                     <ul>

--- a/templates/organizations/tickets/new.html.twig
+++ b/templates/organizations/tickets/new.html.twig
@@ -33,7 +33,7 @@
                         {{ 'tickets.type' | trans }}
                     </label>
 
-                    <div class="row row--always">
+                    <div class="row row--always flow">
                         <div>
                             <input
                                 type="radio"
@@ -129,7 +129,7 @@
             </div>
 
             {% if is_granted('orga:update:tickets:actors', organization) %}
-                <div class="row">
+                <div class="row flow">
                     <div class="row__item--extend flow-small">
                         <label for="requester">
                             {{ icon('user') }}
@@ -210,7 +210,7 @@
 
             {% if is_granted('orga:update:tickets:priority', organization) %}
                 <details
-                    class="flow-small"
+                    class="flow"
                     {{ not (urgency == impact == priority == 'medium') ? 'open' }}
                 >
                     <summary>
@@ -218,7 +218,7 @@
                         {{ 'tickets.priority' | trans }}
                     </summary>
 
-                    <div class="row">
+                    <div class="row flow">
                         <div class="row__item--extend flow-small">
                             <label for="urgency">
                                 {{ 'tickets.urgency' | trans }}

--- a/templates/pages/home.html.twig
+++ b/templates/pages/home.html.twig
@@ -15,7 +15,7 @@
         <div class="wrapper-large wrapper--center flow-larger">
             {% if tickets %}
                 <div class="flow">
-                    <div class="row row--center row--always">
+                    <div class="row row--center row--always flow">
                         <h2 class="row__item--extend">{{ 'home.your_tickets' | trans }}</h2>
 
                         <a class="text--small" href="{{ path('tickets', { assignee: app.user.uid }) }}">

--- a/templates/tickets/index.html.twig
+++ b/templates/tickets/index.html.twig
@@ -22,7 +22,7 @@
             <h1>{{ title }}</h1>
         </div>
 
-        <div class="row">
+        <div class="row flow">
             {% if is_granted('orga:see:tickets:all', 'any') %}
                 <nav class="tickets__nav row__item--noshrink card flow">
                     <ul>

--- a/templates/tickets/priority/edit.html.twig
+++ b/templates/tickets/priority/edit.html.twig
@@ -22,7 +22,7 @@
             {{ include('alerts/_error.html.twig', { message: error | trans }, with_context = false) }}
         {% endif %}
 
-        <div class="row">
+        <div class="row flow">
             <div class="row__item--extend flow-small">
                 <label for="urgency">
                     {{ 'tickets.urgency' | trans }}

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -38,9 +38,9 @@
             </span>
         </div>
 
-        <div class="wrapper-larger wrapper--center row">
-            <div class="ticket__timeline row__item--extend flow-large">
-                <div class="flow-large timeline">
+        <div class="wrapper-larger wrapper--center row flow-larger">
+            <div class="ticket__timeline row__item--extend flow-larger">
+                <div class="flow-larger timeline">
                     {% set timelineDate = null %}
                     {% for timelineItem in timeline.sortedItems %}
                         {% if timelineDate == null or timelineDate.format('Y-m-d') != timelineItem.createdAt.format('Y-m-d') %}
@@ -131,12 +131,12 @@
                             >{{ message }}</textarea>
                         </div>
 
-                        <div class="row">
+                        <div class="row flow">
                             <label>
                                 {{ 'tickets.show.mark_as' | trans }}
                             </label>
 
-                            <div class="row row--always">
+                            <div class="row row--always flow">
                                 {% if is_granted('orga:create:tickets:messages:confidential', organization) %}
                                     <div>
                                         <input
@@ -183,10 +183,10 @@
                             </p>
                         {% endif %}
 
-                        <div class="row">
+                        <div class="row flow">
                             {% if not ticket.isFinished %}
                                 <div class="row__item--extend flow-small">
-                                    <div class="row row--center row--always">
+                                    <div class="row row--center row--always flow">
                                         <label for="status">
                                             {{ 'tickets.show.status_to' | trans }}
                                         </label>
@@ -293,7 +293,7 @@
                 {% endif %}
 
                 <div class="flow">
-                    <div class="row row--center row--always">
+                    <div class="row row--center row--always flow">
                         <span class="row__item--extend text--secondary">
                             {{ icon('user-group') }}
                             <strong>{{ 'tickets.actors' | trans }}</strong>
@@ -357,7 +357,7 @@
                 </div>
 
                 <div class="flow">
-                    <div class="row row--center row--always">
+                    <div class="row row--center row--always flow">
                         <span class="row__item--extend text--secondary">
                             {{ icon('priority') }}
                             <strong>{{ 'tickets.priority' | trans }}</strong>

--- a/templates/users/authorizations/new.html.twig
+++ b/templates/users/authorizations/new.html.twig
@@ -29,7 +29,7 @@
                 {{ include('alerts/_error.html.twig', { message: error | trans }, with_context = false) }}
             {% endif %}
 
-            <div class="row row--always">
+            <div class="row row--always flow">
                 <div>
                     <input
                         type="radio"

--- a/templates/users/index.html.twig
+++ b/templates/users/index.html.twig
@@ -19,7 +19,7 @@
         </div>
 
         <div class="wrapper-large flow">
-            <div class="row row--center">
+            <div class="row row--center row--always flow">
                 <a href="{{ path('new user') }}" class="anchor--action">
                     {{ icon('plus') }}
                     {{ 'users.index.new_user' | trans }}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/242

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- remove margins from the `.row` class
- remove margins from the `.tickets-show .ticket__info` class
- apply `.flow` spaces to rows correctly (i.e. apply a margin-left instead of a margin-top on big screens or with `.row--always`)
- add `.flow*` classes to elements that already have a `.row` class

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- navigate on Bileto either on big and small screens → check everything looks fine

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
