### PR TITLE
fix: Follow the redirections after submitting forms in modals

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -28,6 +28,14 @@ application.register('new-authorization-form', NewAuthorizationFormController);
 application.register('ticket-editor', TicketEditorController);
 application.register('tinymce', TinymceController);
 
+// Make sure to visit the response when receiving the `turbo:frame-missing` event.
+// This happens most of the time on redirection after submitting a form in a modal.
+// Otherwise, "Content missing" would be displayed within the modal.
+document.addEventListener('turbo:frame-missing', (event) => {
+    event.preventDefault();
+    event.detail.visit(event.detail.response);
+});
+
 // Allow to disable the automatic scroll-to-top on form submission.
 // Submitting forms with a `data-turbo-preserve-scroll` attribute will keep the
 // scroll position at the current position.


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- listen for `turbo:frame-missing` to follow the redirections

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- edit the priority of a ticket and submit → check the modal disappears and that the correct priority is displayed

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
