### PR TITLE
sec: Check access correctly in Tickets-related controllers

### DIFF
--- a/src/Controller/Tickets/ActorsController.php
+++ b/src/Controller/Tickets/ActorsController.php
@@ -26,6 +26,13 @@ class ActorsController extends BaseController
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:actors', $organization);
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         $users = $actorsLister->listUsers();
         $requester = $ticket->getRequester();
         $assignee = $ticket->getAssignee();
@@ -47,6 +54,13 @@ class ActorsController extends BaseController
     ): Response {
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:actors', $organization);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
 
         $initialRequester = $ticket->getRequester();
         $initialAssignee = $ticket->getAssignee();

--- a/src/Controller/Tickets/MessagesController.php
+++ b/src/Controller/Tickets/MessagesController.php
@@ -42,6 +42,10 @@ class MessagesController extends BaseController
         /** @var \App\Entity\User $user */
         $user = $this->getUser();
 
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         /** @var string $messageContent */
         $messageContent = $request->request->get('message', '');
         $messageContent = $appMessageSanitizer->sanitize($messageContent);

--- a/src/Controller/Tickets/PriorityController.php
+++ b/src/Controller/Tickets/PriorityController.php
@@ -22,6 +22,13 @@ class PriorityController extends BaseController
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:priority', $organization);
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         return $this->render('tickets/priority/edit.html.twig', [
             'ticket' => $ticket,
             'urgency' => $ticket->getUrgency(),
@@ -39,6 +46,13 @@ class PriorityController extends BaseController
     ): Response {
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:priority', $organization);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
 
         /** @var string $urgency */
         $urgency = $request->request->get('urgency', $ticket->getUrgency());

--- a/src/Controller/Tickets/StatusController.php
+++ b/src/Controller/Tickets/StatusController.php
@@ -22,6 +22,13 @@ class StatusController extends BaseController
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:status', $organization);
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         $statuses = Ticket::getStatusesWithLabels();
 
         return $this->render('tickets/status/edit.html.twig', [
@@ -40,6 +47,13 @@ class StatusController extends BaseController
     ): Response {
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:status', $organization);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
 
         /** @var string $status */
         $status = $request->request->get('status', $ticket->getStatus());

--- a/src/Controller/Tickets/TitleController.php
+++ b/src/Controller/Tickets/TitleController.php
@@ -22,6 +22,13 @@ class TitleController extends BaseController
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:title', $organization);
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         return $this->render('tickets/title/edit.html.twig', [
             'ticket' => $ticket,
             'title' => $ticket->getTitle(),
@@ -37,6 +44,13 @@ class TitleController extends BaseController
     ): Response {
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:title', $organization);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
 
         $oldTitle = $ticket->getTitle();
 

--- a/src/Controller/Tickets/TypeController.php
+++ b/src/Controller/Tickets/TypeController.php
@@ -26,6 +26,13 @@ class TypeController extends BaseController
         $organization = $ticket->getOrganization();
         $this->denyAccessUnlessGranted('orga:update:tickets:type', $organization);
 
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        if (!$ticket->hasActor($user)) {
+            $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
+        }
+
         $oldType = $ticket->getType();
 
         /** @var string $type */

--- a/tests/Controller/Tickets/MessagesControllerTest.php
+++ b/tests/Controller/Tickets/MessagesControllerTest.php
@@ -356,7 +356,25 @@ class MessagesControllerTest extends WebTestCase
 
         $client->catchExceptions(false);
         $client->request('POST', "/tickets/{$ticket->getUid()}/messages/new", [
-            '_csrf_token' => 'not the token',
+            '_csrf_token' => $this->generateCsrfToken($client, 'create ticket message'),
+            'message' => $messageContent,
+        ]);
+    }
+
+    public function testPostCreateFailsIfAccessToTicketIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantOrga($user->object(), ['orga:create:tickets:messages']);
+        $ticket = TicketFactory::createOne();
+        $messageContent = 'My message';
+
+        $client->catchExceptions(false);
+        $client->request('POST', "/tickets/{$ticket->getUid()}/messages/new", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'create ticket message'),
             'message' => $messageContent,
         ]);
     }

--- a/tests/Controller/Tickets/TitleControllerTest.php
+++ b/tests/Controller/Tickets/TitleControllerTest.php
@@ -53,6 +53,20 @@ class TitleControllerTest extends WebTestCase
         $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
     }
 
+    public function testGetEditFailsIfAccessToTicketIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantOrga($user->object(), ['orga:update:tickets:title']);
+        $ticket = TicketFactory::createOne();
+
+        $client->catchExceptions(false);
+        $client->request('GET', "/tickets/{$ticket->getUid()}/title/edit");
+    }
+
     public function testPostUpdateSavesTicketAndRedirects(): void
     {
         $client = static::createClient();
@@ -133,6 +147,27 @@ class TitleControllerTest extends WebTestCase
         $newTitle = 'My urgent ticket!';
         $ticket = TicketFactory::createOne([
             'createdBy' => $user,
+            'title' => $oldTitle,
+        ]);
+
+        $client->catchExceptions(false);
+        $client->request('POST', "/tickets/{$ticket->getUid()}/title/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket title'),
+            'title' => $newTitle,
+        ]);
+    }
+
+    public function testPostUpdateFailsIfAccessToTicketIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantOrga($user->object(), ['orga:update:tickets:title']);
+        $oldTitle = 'My ticket';
+        $newTitle = 'My urgent ticket!';
+        $ticket = TicketFactory::createOne([
             'title' => $oldTitle,
         ]);
 

--- a/tests/Controller/Tickets/TypeControllerTest.php
+++ b/tests/Controller/Tickets/TypeControllerTest.php
@@ -113,4 +113,25 @@ class TypeControllerTest extends WebTestCase
             'type' => $newType,
         ]);
     }
+
+    public function testPostUpdateFailsIfAccessToTicketIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantOrga($user->object(), ['orga:update:tickets:type']);
+        $oldType = 'request';
+        $newType = 'incident';
+        $ticket = TicketFactory::createOne([
+            'type' => $oldType,
+        ]);
+
+        $client->catchExceptions(false);
+        $client->request('POST', "/tickets/{$ticket->getUid()}/type/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket type'),
+            'type' => $newType,
+        ]);
+    }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- Check if the user has access to the ticket in the Tickets resources-controllers (i.e. under `Controllers/Tickets/*`)

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- give a role with all the "update * of a ticket" permissions, but not "see all the tickets"
- go to the URL of a ticket which he has NO access → check you can't access the page
- do the same by appending `/actors/edit`, `/priority/edit`, `/status/edit` and `/title/edit` to the URL → check you can't access the pages

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
