### PR TITLE
fix: Allow public access to the Web Manifest

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -38,6 +38,7 @@ security:
         - { path: ^/about, role: PUBLIC_ACCESS }
         - { path: ^/login, role: PUBLIC_ACCESS }
         - { path: ^/session/locale, role: PUBLIC_ACCESS }
+        - { path: ^/app.manifest, role: PUBLIC_ACCESS }
         - { path: ^/, role: ROLE_USER }
 
 when@test:


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add the /app.manifest URL to the public URLs

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- while being disconnected, access http://localhost:8000/app.manifest
- check it displays the manifest

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
