### PR TITLE
tec: Disable XDebug when running PHPStan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: ## Run the test suite
 
 .PHONY: lint
 lint: ## Execute the linter (PHPStan and PHP_CodeSniffer)
-	$(PHP) vendor/bin/phpstan analyse --xdebug --memory-limit 1G -c .phpstan.neon
+	$(PHP) vendor/bin/phpstan analyse --memory-limit 1G -c .phpstan.neon
 	$(PHP) vendor/bin/phpcs
 	$(CONSOLE) lint:container
 	$(CONSOLE) lint:twig


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- remove the `--xdebug` option when running PHPStan

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make lint`, it should go faster than previously

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
