### PR TITLE
imp: Add margin below the modal title

### DIFF
--- a/assets/stylesheets/components/modal.css
+++ b/assets/stylesheets/components/modal.css
@@ -76,6 +76,8 @@
 }
 
 .modal__title {
+    margin-bottom: 2rem;
+
     text-align: center;
 }
 

--- a/templates/pages/advanced_search_syntax.html.twig
+++ b/templates/pages/advanced_search_syntax.html.twig
@@ -10,8 +10,6 @@
 
 {% block body %}
     <div class="wrapper-text wrapper--center flow-larger">
-        <div></div>
-
         <div class="flow">
             <p>
                 {{ 'advanced_search_syntax.intro1' | trans }}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add margin below the modal title
- remove the div from the advanced search syntax modal which was used to add space

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- open the modals of the application → check there is space below the titles

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
