### PR TITLE
imp: Allow to set password when creating users

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -67,9 +67,6 @@ class User implements
     )]
     private ?string $email = null;
 
-    /**
-     * @var string The hashed password
-     */
     #[ORM\Column]
     private ?string $password = null;
 

--- a/templates/users/new.html.twig
+++ b/templates/users/new.html.twig
@@ -84,6 +84,38 @@
                 />
             </div>
 
+            <div class="flow-small">
+                <label for="password">
+                    {{ 'users.password' | trans }}
+                    <span class="text--secondary">
+                        {{ 'users.new.leave_password_empty' | trans }}
+                    </span>
+                </label>
+
+                <div class="input-container" data-controller="password">
+                    <input
+                        type="password"
+                        id="password"
+                        name="password"
+                        autocomplete="new-password"
+                        data-password-target="input"
+                    />
+
+                    <button
+                        type="button"
+                        role="switch"
+                        data-action="password#toggle"
+                        data-password-target="button"
+                    >
+                        {{ icon('eye') }}
+                        {{ icon('eye-slash') }}
+                        <span class="sr-only">
+                            {{ 'forms.show_password' | trans }}
+                        </span>
+                    </button>
+                </div>
+            </div>
+
             <div class="form__actions">
                 <button id="form-create-user-submit" class="button--primary" type="submit">
                     {{ 'users.new.submit' | trans }}

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -87,11 +87,14 @@ class UsersControllerTest extends WebTestCase
     public function testPostCreateCreatesTheUserAndRedirects(): void
     {
         $client = static::createClient();
+        /** @var \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface */
+        $passwordHasher = self::getContainer()->get('security.user_password_hasher');
         $user = UserFactory::createOne();
         $client->loginUser($user->object());
         $this->grantAdmin($user->object(), ['admin:manage:users']);
         $email = 'alix@example.com';
         $name = 'Alix Pataquès';
+        $password = 'secret';
 
         $this->assertSame(1, UserFactory::count());
 
@@ -99,6 +102,7 @@ class UsersControllerTest extends WebTestCase
         $crawler = $client->submitForm('form-create-user-submit', [
             'email' => $email,
             'name' => $name,
+            'password' => $password,
         ]);
 
         $this->assertSame(2, UserFactory::count());
@@ -108,6 +112,7 @@ class UsersControllerTest extends WebTestCase
         $this->assertSame($name, $newUser->getName());
         $this->assertSame($user->getLocale(), $newUser->getLocale());
         $this->assertSame(20, strlen($newUser->getUid()));
+        $this->assertTrue($passwordHasher->isPasswordValid($newUser->object(), $password));
     }
 
     public function testPostCreateFailsIfEmailIsAlreadyUsed(): void

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -267,6 +267,7 @@ users.index.title: Users
 users.language: Language
 users.n_others: '{number, plural, =0 {no other} one {1 other} other {# other}}'
 users.name: Name
+users.new.leave_password_empty: '(leave empty to forbid login)'
 users.new.submit: 'Create the user'
 users.new.title: 'New user'
 users.password: Password

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -267,6 +267,7 @@ users.index.title: Utilisateurs
 users.language: Langue
 users.n_others: '{number, plural, =0 {aucun autre} one {1 autre} other {# autres}}'
 users.name: Nom
+users.new.leave_password_empty: '(laissez vide pour empêcher la connexion)'
 users.new.submit: 'Créer l’utilisateur'
 users.new.title: 'Nouvel utilisateur'
 users.password: 'Mot de passe'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/276

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add a password input to the "new user" form
- hash the password and set it to the user in the controller
- otherwise, set an empty string (instead of a random string)

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- as an admin, go to the "new user" form
- create a user with a password
- check that you can login with this password
- create a user with no password
- check that you cannot login, even with an empty password

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
