### PR TITLE
new: Allow to assign a user to an organization

### DIFF
--- a/migrations/Version20230606132457AddOrganizationToUsers.php
+++ b/migrations/Version20230606132457AddOrganizationToUsers.php
@@ -1,0 +1,61 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230606132457AddOrganizationToUsers extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add an organization_id column to the users table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform()->getName();
+        if ($dbPlatform === 'postgresql') {
+            $this->addSql('ALTER TABLE users ADD organization_id INT DEFAULT NULL');
+            $this->addSql(<<<SQL
+                ALTER TABLE users
+                ADD CONSTRAINT FK_1483A5E932C8A3DE
+                FOREIGN KEY (organization_id)
+                REFERENCES organization (id)
+                ON DELETE SET NULL
+                NOT DEFERRABLE INITIALLY IMMEDIATE
+            SQL);
+            $this->addSql('CREATE INDEX IDX_1483A5E932C8A3DE ON users (organization_id)');
+        } elseif ($dbPlatform === 'mysql') {
+            $this->addSql('ALTER TABLE users ADD organization_id INT DEFAULT NULL');
+            $this->addSql(<<<SQL
+                ALTER TABLE users
+                ADD CONSTRAINT FK_1483A5E932C8A3DE
+                FOREIGN KEY (organization_id)
+                REFERENCES organization (id)
+                ON DELETE SET NULL
+            SQL);
+            $this->addSql('CREATE INDEX IDX_1483A5E932C8A3DE ON users (organization_id)');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform()->getName();
+        if ($dbPlatform === 'postgresql') {
+            $this->addSql('ALTER TABLE "users" DROP CONSTRAINT FK_1483A5E932C8A3DE');
+            $this->addSql('DROP INDEX IDX_1483A5E932C8A3DE');
+            $this->addSql('ALTER TABLE "users" DROP organization_id');
+        } elseif ($dbPlatform === 'mysql') {
+            $this->addSql('ALTER TABLE `users` DROP FOREIGN KEY FK_1483A5E932C8A3DE');
+            $this->addSql('DROP INDEX IDX_1483A5E932C8A3DE ON `users`');
+            $this->addSql('ALTER TABLE `users` DROP organization_id');
+        }
+    }
+}

--- a/src/Command/SeedsCommand.php
+++ b/src/Command/SeedsCommand.php
@@ -140,6 +140,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Alix Hambourg',
                 'password' => $password,
+                'organization' => $orgaProbesys,
             ]);
 
             $userBenedict = $this->userRepository->findOneOrCreateBy([
@@ -147,6 +148,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Benedict Aphone',
                 'password' => $password,
+                'organization' => $orgaWebDivision,
             ]);
 
             $userCharlie = $this->userRepository->findOneOrCreateBy([
@@ -154,6 +156,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Charlie Gature',
                 'password' => $password,
+                'organization' => $orgaFriendlyCoorp,
             ]);
 
             foreach ([$userAlix, $userBenedict, $userCharlie] as $user) {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -100,6 +100,10 @@ class User implements
     #[ORM\Column]
     private ?bool $hideEvents = false;
 
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    private ?Organization $organization = null;
+
     public function __construct()
     {
         $this->authorizations = new ArrayCollection();
@@ -240,6 +244,18 @@ class User implements
     public function setHideEvents(bool $hideEvents): self
     {
         $this->hideEvents = $hideEvents;
+
+        return $this;
+    }
+
+    public function getOrganization(): ?Organization
+    {
+        return $this->organization;
+    }
+
+    public function setOrganization(?Organization $organization): self
+    {
+        $this->organization = $organization;
 
         return $this;
     }

--- a/templates/users/new.html.twig
+++ b/templates/users/new.html.twig
@@ -115,6 +115,46 @@
                 </div>
             </div>
 
+            <div class="flow flow--small">
+                <label for="organization">
+                    {{ 'users.organization' | trans }}
+                </label>
+
+                <p class="form__caption" id="organization-caption">
+                    {{ 'users.new.organization_caption' | trans }}
+                </p>
+
+                {% if errors.organization is defined %}
+                    <p class="form__error" role="alert" id="organization-error">
+                        <span class="sr-only">{{ 'forms.error' | trans }}</span>
+                        {{ errors.organization }}
+                    </p>
+                {% endif %}
+
+                <select
+                    id="organization"
+                    name="organization"
+                    aria-describedby="organization-caption"
+                    {% if errors.organization is defined %}
+                        aria-invalid="true"
+                        aria-errormessage="organization-error"
+                    {% endif %}
+                >
+                    <option value="">
+                        {{ 'users.no_organization' | trans }}
+                    </option>
+
+                    {{ include(
+                        'organizations/_organizations_as_options.html.twig',
+                        {
+                            organizations: organizations,
+                            selected: organizationUid,
+                        },
+                        with_context = false
+                    ) }}
+                </select>
+            </div>
+
             <div class="form__actions">
                 <button id="form-create-user-submit" class="button--primary" type="submit">
                     {{ 'users.new.submit' | trans }}

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -8,6 +8,7 @@ namespace App\Tests\Controller;
 
 use App\Entity\User;
 use App\Tests\AuthorizationHelper;
+use App\Tests\Factory\OrganizationFactory;
 use App\Tests\Factory\UserFactory;
 use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -95,6 +96,7 @@ class UsersControllerTest extends WebTestCase
         $email = 'alix@example.com';
         $name = 'Alix Pataquès';
         $password = 'secret';
+        $organization = OrganizationFactory::createOne();
 
         $this->assertSame(1, UserFactory::count());
 
@@ -103,6 +105,7 @@ class UsersControllerTest extends WebTestCase
             'email' => $email,
             'name' => $name,
             'password' => $password,
+            'organization' => $organization->getUid(),
         ]);
 
         $this->assertSame(2, UserFactory::count());
@@ -113,6 +116,7 @@ class UsersControllerTest extends WebTestCase
         $this->assertSame($user->getLocale(), $newUser->getLocale());
         $this->assertSame(20, strlen($newUser->getUid()));
         $this->assertTrue($passwordHasher->isPasswordValid($newUser->object(), $password));
+        $this->assertSame($organization->getId(), $newUser->getOrganization()->getId());
     }
 
     public function testPostCreateFailsIfEmailIsAlreadyUsed(): void

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -286,7 +286,10 @@ users.language: Language
 users.n_others: '{number, plural, =0 {no other} one {1 other} other {# other}}'
 users.name: Name
 users.new.leave_password_empty: '(leave empty to forbid login)'
+users.new.organization_caption: 'The tickets opened by email by this user will be attached to this organization.'
 users.new.submit: 'Create the user'
 users.new.title: 'New user'
+users.no_organization: 'No organization'
+users.organization: Organization
 users.password: Password
 users.yourself: yourself

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -286,7 +286,10 @@ users.language: Langue
 users.n_others: '{number, plural, =0 {aucun autre} one {1 autre} other {# autres}}'
 users.name: Nom
 users.new.leave_password_empty: '(laissez vide pour empêcher la connexion)'
+users.new.organization_caption: 'Les tickets ouverts par email par cet utilisateur seront attachés à cette organisation.'
 users.new.submit: 'Créer l’utilisateur'
 users.new.title: 'Nouvel utilisateur'
+users.no_organization: 'Aucune organisation'
+users.organization: Organisation
 users.password: 'Mot de passe'
 users.yourself: vous


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/17

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add an organization relation to the User entity
- add a select box to the "new user" form to select an organization

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- go to settings > users > new user
- create a user and set an organization
- with the psql command, check that the user has an organization (`SELECT * FROM users;`)

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
