### PR TITLE
tec: Fix the version number of MariaDB on the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,4 +86,4 @@ jobs:
             - name: Run the test suite
               run: make test
               env:
-                  DATABASE_URL: 'mysql://root:mariadb@127.0.0.1:3306/bileto?serverVersion=mariadb-10.4.29'
+                  DATABASE_URL: 'mysql://root:mariadb@127.0.0.1:3306/bileto?serverVersion=10.4.29-MariaDB'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- change the version number of MariaDB

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- check in GitHub Actions that the message "Version detection logic for MySQL will change in DBAL 4." is no longer displayed

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
