### PR TITLE
new: Import MailboxEmails as Tickets

### DIFF
--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -14,6 +14,8 @@ framework:
                 allowed_media_schemes: ['http', 'https']
                 allow_relative_medias: false
 
+                block_elements: ['html', 'body']
+
                 force_attributes:
                     a:
                         rel: noopener noreferrer

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -20,3 +20,5 @@ framework:
                     a:
                         rel: noopener noreferrer
                         target: _blank
+
+                max_input_length: 1000000

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -13,6 +13,7 @@ Dedicated to the backend:
 - [Declaring a new Entity](/docs/developers/entity.md)
 - [Working with the search engine](/docs/developers/search-engine.md)
 - [Encrypting data](/docs/developers/encryptor.md)
+- [The email collector](/docs/developers/email-collector.md)
 
 Dedicated to the frontend:
 

--- a/docs/developers/email-collector.md
+++ b/docs/developers/email-collector.md
@@ -1,0 +1,33 @@
+# The email collector
+
+Bileto allows you to configure mailboxes to receive emails.
+These emails are retrieved with <abbr>IMAP</abbr> and can be transformed in tickets.
+
+## The Mailbox entity
+
+The [`Mailbox`](/src/Entity/Mailbox.php) entity stores the information about the mailboxes.
+Mailboxes are managed in the [`MailboxesController`](/src/Controller/MailboxesController.php).
+This controller allows you, among the rest, to collect the emails from the mailboxes.
+
+## The FetchMailboxes handler
+
+When emails are collected, the first thing that Bileto does is to fetch the “Unseen” emails from the mailboxes.
+It is done in the [`FetchMailboxesHandler`](/src/MessageHandler/FetchMailboxesHandler.php).
+
+Its job is to fetch the emails, save them as [`MailboxEmail`](/src/Entity/MailboxEmail.php) entities, and delete them.
+If deletion fails, the emails are marked as “Seen”.
+
+## The CreateTicketsFromMailboxEmails handler
+
+Once the emails are fetched, it's time to import tickets from the `MailboxEmail`s.
+This is the job of the [`CreateTicketsFromMailboxEmailsHandler`](/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php).
+
+For each `MailboxEmail`:
+
+1. it gets the requester (i.e. the `From` header);
+2. it gets the default organization of the requester;
+3. it checks the requester has the permission to create tickets in the organization;
+4. it creates the ticket based on the `Subject`, the `Date` and the `Body` of the email;
+5. it deletes the `MailboxEmail` from the database.
+
+If anything goes wrong during this process, the error is logged in the relevant `MailboxEmail` `lastError` field.

--- a/src/Controller/MailboxesController.php
+++ b/src/Controller/MailboxesController.php
@@ -8,6 +8,7 @@ namespace App\Controller;
 
 use App\Entity\Mailbox;
 use App\Message\FetchMailboxes;
+use App\Message\CreateTicketsFromMailboxEmails;
 use App\Repository\MailboxRepository;
 use App\Security\Encryptor;
 use App\Service\MailboxSorter;
@@ -196,6 +197,7 @@ class MailboxesController extends BaseController
         }
 
         $bus->dispatch(new FetchMailboxes());
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
 
         return $this->redirectToRoute('mailboxes');
     }

--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -8,6 +8,7 @@ namespace App\Entity;
 
 use App\EntityListener\EntitySetMetaListener;
 use App\Repository\MailboxEmailRepository;
+use App\Utils\Time;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Webklex\PHPIMAP;
@@ -97,6 +98,7 @@ class MailboxEmail implements MetaEntityInterface, ActivityRecordableInterface
     public function setLastError(string $lastError): self
     {
         $this->lastError = $lastError;
+        $this->lastErrorAt = Time::now();
 
         return $this;
     }
@@ -104,13 +106,6 @@ class MailboxEmail implements MetaEntityInterface, ActivityRecordableInterface
     public function getLastErrorAt(): ?\DateTimeImmutable
     {
         return $this->lastErrorAt;
-    }
-
-    public function setLastErrorAt(?\DateTimeImmutable $lastErrorAt): self
-    {
-        $this->lastErrorAt = $lastErrorAt;
-
-        return $this;
     }
 
     public function getEmail(): PHPIMAP\Message

--- a/src/Message/CreateTicketsFromMailboxEmails.php
+++ b/src/Message/CreateTicketsFromMailboxEmails.php
@@ -1,0 +1,11 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Message;
+
+class CreateTicketsFromMailboxEmails
+{
+}

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -1,0 +1,107 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\MessageHandler;
+
+use App\Entity\Ticket;
+use App\Entity\MailboxEmail;
+use App\Entity\Message;
+use App\Message\CreateTicketsFromMailboxEmails;
+use App\Repository\MailboxRepository;
+use App\Repository\MailboxEmailRepository;
+use App\Repository\MessageRepository;
+use App\Repository\TicketRepository;
+use App\Repository\UserRepository;
+use App\Security\Authentication\UserToken;
+use App\Security\Encryptor;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Webklex\PHPIMAP;
+
+#[AsMessageHandler]
+class CreateTicketsFromMailboxEmailsHandler
+{
+    public function __construct(
+        private MailboxEmailRepository $mailboxEmailRepository,
+        private MessageRepository $messageRepository,
+        private TicketRepository $ticketRepository,
+        private UserRepository $userRepository,
+        private AccessDecisionManagerInterface $accessDecisionManager,
+        private HtmlSanitizerInterface $appMessageSanitizer,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(CreateTicketsFromMailboxEmails $message): void
+    {
+        $mailboxEmails = $this->mailboxEmailRepository->findAll();
+
+        foreach ($mailboxEmails as $mailboxEmail) {
+            $senderEmail = $mailboxEmail->getFrom();
+
+            $requester = $this->userRepository->findOneBy([
+                'email' => $senderEmail,
+            ]);
+
+            if (!$requester) {
+                $this->markError($mailboxEmail, 'unknown sender');
+                continue;
+            }
+
+            $organization = $requester->getOrganization();
+
+            if (!$organization) {
+                $this->markError($mailboxEmail, 'sender is not attached to an organization');
+                continue;
+            }
+
+            $token = new UserToken($requester);
+
+            if (!$this->accessDecisionManager->decide($token, ['orga:create:tickets'], $organization)) {
+                $this->markError($mailboxEmail, 'sender has not permission to create tickets');
+                continue;
+            }
+
+            $subject = $mailboxEmail->getSubject();
+            $messageContent = $this->appMessageSanitizer->sanitize($mailboxEmail->getBody());
+            $date = $mailboxEmail->getDate();
+
+            $ticket = new Ticket();
+            $ticket->setCreatedAt($date);
+            $ticket->setCreatedBy($requester);
+            $ticket->setTitle($subject);
+            $ticket->setType(Ticket::DEFAULT_TYPE);
+            $ticket->setStatus(Ticket::DEFAULT_STATUS);
+            $ticket->setUrgency(Ticket::DEFAULT_WEIGHT);
+            $ticket->setImpact(Ticket::DEFAULT_WEIGHT);
+            $ticket->setPriority(Ticket::DEFAULT_WEIGHT);
+            $ticket->setOrganization($organization);
+            $ticket->setRequester($requester);
+
+            $message = new Message();
+            $message->setCreatedAt($date);
+            $message->setCreatedBy($requester);
+            $message->setContent($messageContent);
+            $message->setTicket($ticket);
+            $message->setIsConfidential(false);
+            $message->setVia('email');
+
+            $this->ticketRepository->save($ticket, true);
+            $this->messageRepository->save($message, true);
+            $this->mailboxEmailRepository->remove($mailboxEmail, true);
+        }
+    }
+
+    private function markError(MailboxEmail $mailboxEmail, string $error): void
+    {
+        $this->logger->warning("MailboxEmail {$mailboxEmail->getId()} cannot be imported: {$error}");
+
+        $mailboxEmail->setLastError($error);
+        $this->mailboxEmailRepository->save($mailboxEmail, true);
+    }
+}

--- a/src/MessageHandler/FetchMailboxesHandler.php
+++ b/src/MessageHandler/FetchMailboxesHandler.php
@@ -71,7 +71,6 @@ class FetchMailboxesHandler
             $client->disconnect();
         } catch (\Exception $e) {
             $this->logger->error("Mailbox #{$mailbox->getId()} error: {$e->getMessage()}");
-            return;
         }
     }
 }

--- a/src/Security/Authentication/UserToken.php
+++ b/src/Security/Authentication/UserToken.php
@@ -1,0 +1,20 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserToken extends AbstractToken
+{
+    public function __construct(UserInterface $user)
+    {
+        parent::__construct($user->getRoles());
+
+        $this->setUser($user);
+    }
+}

--- a/tests/Factory/MailboxEmailFactory.php
+++ b/tests/Factory/MailboxEmailFactory.php
@@ -1,0 +1,95 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Factory;
+
+use App\Entity\MailboxEmail;
+use App\Repository\MailboxEmailRepository;
+use App\Security\Encryptor;
+use App\Utils\Random;
+use Zenstruck\Foundry\Instantiator;
+use Zenstruck\Foundry\RepositoryProxy;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Webklex\PHPIMAP;
+
+/**
+ * @extends ModelFactory<MailboxEmail>
+ *
+ * @method static MailboxEmail|Proxy createOne(array $attributes = [])
+ * @method static MailboxEmail[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @method static MailboxEmail[]|Proxy[] createSequence(array|callable $sequence)
+ * @method static MailboxEmail|Proxy find(object|array|mixed $criteria)
+ * @method static MailboxEmail|Proxy findOrCreate(array $attributes)
+ * @method static MailboxEmail|Proxy first(string $sortedField = 'id')
+ * @method static MailboxEmail|Proxy last(string $sortedField = 'id')
+ * @method static MailboxEmail|Proxy random(array $attributes = [])
+ * @method static MailboxEmail|Proxy randomOrCreate(array $attributes = [])
+ * @method static MailboxEmail[]|Proxy[] all()
+ * @method static MailboxEmail[]|Proxy[] findBy(array $attributes)
+ * @method static MailboxEmail[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static MailboxEmail[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
+ * @method static MailboxEmailRepository|RepositoryProxy repository()
+ * @method MailboxEmail|Proxy create(array|callable $attributes = [])
+ *
+ * @phpstan-method static MailboxEmail&Proxy createOne(array $attributes = [])
+ * @phpstan-method static MailboxEmail[]&Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @phpstan-method static MailboxEmail[]&Proxy[] createSequence(array|callable $sequence)
+ * @phpstan-method static MailboxEmail&Proxy find(object|array|mixed $criteria)
+ * @phpstan-method static MailboxEmail&Proxy findOrCreate(array $attributes)
+ * @phpstan-method static MailboxEmail&Proxy first(string $sortedField = 'id')
+ * @phpstan-method static MailboxEmail&Proxy last(string $sortedField = 'id')
+ * @phpstan-method static MailboxEmail&Proxy random(array $attributes = [])
+ * @phpstan-method static MailboxEmail&Proxy randomOrCreate(array $attributes = [])
+ * @phpstan-method static MailboxEmail[]&Proxy[] all()
+ * @phpstan-method static MailboxEmail[]&Proxy[] findBy(array $attributes)
+ * @phpstan-method static MailboxEmail[]&Proxy[] randomSet(int $number, array $attributes = [])
+ * @phpstan-method static MailboxEmail[]&Proxy[] randomRange(int $min, int $max, array $attributes = [])
+ * @phpstan-method MailboxEmail&Proxy create(array|callable $attributes = [])
+ */
+final class MailboxEmailFactory extends ModelFactory
+{
+    /**
+     * @return mixed[]
+     */
+    protected function getDefaults(): array
+    {
+        return [
+            'date' => self::faker()->dateTime(),
+            'from' => self::faker()->email(),
+            'subject' => self::faker()->words(3, true),
+            'htmlBody' => self::faker()->randomHtml(),
+            'mailbox' => MailboxFactory::new(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->instantiateWith(function (array $attributes, string $class): MailboxEmail {
+            $rawEmail = <<<TEXT
+                Subject: {$attributes['subject']}\r
+                From: <{$attributes['from']}>\r
+                To: support@example.com\r
+                Date: {$attributes['date']->format(DATE_RFC1123)}\r
+                Content-Type: text/html\r
+                \r
+                \r
+                {$attributes['htmlBody']}
+
+                TEXT;
+
+            $clientManager = new PHPIMAP\ClientManager();
+            $email = PHPIMAP\Message::fromString($rawEmail);
+
+            return new MailboxEmail($attributes['mailbox'], $email);
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return MailboxEmail::class;
+    }
+}

--- a/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
+++ b/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\CreateTicketsFromMailboxEmails;
+use App\Tests\AuthorizationHelper;
+use App\Tests\Factory\MailboxEmailFactory;
+use App\Tests\Factory\MessageFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\TicketFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class CreateTicketsFromMailboxEmailsHandlerTest extends WebTestCase
+{
+    use AuthorizationHelper;
+    use Factories;
+    use ResetDatabase;
+
+    public function testInvokeCreatesATicketFromAMailboxEmail(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+        /** @var HtmlSanitizerInterface */
+        $appMessageSanitizer = $container->get('html_sanitizer.sanitizer.app.message_sanitizer');
+
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+        ]);
+        $this->grantOrga($user->object(), ['orga:create:tickets'], $organization->object());
+        $date = Factory::faker()->dateTime();
+        $subject = Factory::faker()->words(3, true);
+        $body = Factory::faker()->randomHtml();
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'date' => $date,
+            'from' => $user->getEmail(),
+            'subject' => $subject,
+            'htmlBody' => $body,
+        ]);
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(0, MailboxEmailFactory::count());
+        $this->assertSame(1, TicketFactory::count());
+        $this->assertSame(1, MessageFactory::count());
+
+        $ticket = TicketFactory::first();
+        $this->assertEquals($date, $ticket->getCreatedAt());
+        $this->assertSame($user->getId(), $ticket->getCreatedBy()->getId());
+        $this->assertSame($subject, $ticket->getTitle());
+        $this->assertSame($organization->getId(), $ticket->getOrganization()->getId());
+        $this->assertSame($user->getId(), $ticket->getRequester()->getId());
+
+        $message = MessageFactory::first();
+        $this->assertEquals($date, $message->getCreatedAt());
+        $this->assertSame($user->getId(), $message->getCreatedBy()->getId());
+        $sanitizedBody = trim($appMessageSanitizer->sanitize($body));
+        $this->assertSame($sanitizedBody, $message->getContent());
+        $this->assertSame($ticket->getId(), $message->getTicket()->getId());
+        $this->assertFalse($message->isConfidential());
+        $this->assertSame('email', $message->getVia());
+    }
+
+    public function testInvokeFailsIfRequesterDoesNotExists(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => Factory::faker()->email(),
+        ]);
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $mailboxEmail->refresh();
+        $this->assertSame('unknown sender', $mailboxEmail->getLastError());
+    }
+
+    public function testInvokeFailsIfRequesterHasNoOrganization(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $user = UserFactory::createOne([
+            'organization' => null,
+        ]);
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => $user->getEmail(),
+        ]);
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $mailboxEmail->refresh();
+        $this->assertSame('sender is not attached to an organization', $mailboxEmail->getLastError());
+    }
+
+    public function testInvokeFailsIfAccessIsForbidden(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+        ]);
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => $user->getEmail(),
+        ]);
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $mailboxEmail->refresh();
+        $this->assertSame('sender has not permission to create tickets', $mailboxEmail->getLastError());
+    }
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/43

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add `html` and `body` to the blocked elements of the Html Sanitizer
- add a factory for the `MailboxEmail` entity
- create a `UserToken` to allow checking the permissions of an unauthenticated user
- set `lastErrorAt` when setting `lastError` of `MailboxEmail`
- add a new `ImportMailboxEmails` message + handler (+ tests) to import the `MailboxEmails` as `Tickets`

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- create a mailbox as explained in the GreenMail documentation
- send an email to this mailbox with an email associated to an existing user, associated to an organization itself and with permission to create tickets in this organization
- click on "Collect the mailboxes"
- → check there is a new ticket named after your email subject
- → check there is no MailboxEmail in the database

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
