### PR TITLE
imp: Display Mailbox errors in the list

### DIFF
--- a/migrations/Version20230623122104AddLastErrorToMailbox.php
+++ b/migrations/Version20230623122104AddLastErrorToMailbox.php
@@ -1,0 +1,49 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230623122104AddLastErrorToMailbox extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add last_error* columns to the mailbox table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE mailbox ADD last_error TEXT NOT NULL');
+            $this->addSql('ALTER TABLE mailbox ADD last_error_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+            $this->addSql('COMMENT ON COLUMN mailbox.last_error_at IS \'(DC2Type:datetimetz_immutable)\'');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql(<<<SQL
+                ALTER TABLE mailbox
+                ADD last_error LONGTEXT NOT NULL,
+                ADD last_error_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetimetz_immutable)'
+            SQL);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE mailbox DROP last_error');
+            $this->addSql('ALTER TABLE mailbox DROP last_error_at');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE mailbox DROP last_error, DROP last_error_at');
+        }
+    }
+}

--- a/src/Controller/MailboxesController.php
+++ b/src/Controller/MailboxesController.php
@@ -143,6 +143,7 @@ class MailboxesController extends BaseController
     public function test(
         Request $request,
         Mailbox $mailbox,
+        MailboxRepository $mailboxRepository,
         TranslatorInterface $translator,
         Encryptor $encryptor,
     ): Response {
@@ -171,11 +172,15 @@ class MailboxesController extends BaseController
             $client->connect();
             $client->disconnect();
 
+            $mailbox->setLastError('');
+            $mailboxRepository->save($mailbox, true);
+
             $this->addFlash('success', new TranslatableMessage('mailboxes.test.success'));
         } catch (\Exception $e) {
-            $this->addFlash('error', new TranslatableMessage('mailboxes.test.error', [
-                'error' => $e->getMessage(),
-            ]));
+            $error = $e->getMessage();
+
+            $mailbox->setLastError($error);
+            $mailboxRepository->save($mailbox, true);
         }
 
         return $this->redirectToRoute('mailboxes');

--- a/src/Entity/Mailbox.php
+++ b/src/Entity/Mailbox.php
@@ -8,6 +8,7 @@ namespace App\Entity;
 
 use App\EntityListener\EntitySetMetaListener;
 use App\Repository\MailboxRepository;
+use App\Utils\Time;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -90,6 +91,17 @@ class Mailbox implements MetaEntityInterface, ActivityRecordableInterface
         message: new TranslatableMessage('mailbox.folder.required', [], 'errors'),
     )]
     private ?string $folder = null;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private ?string $lastError = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $lastErrorAt = null;
+
+    public function __construct()
+    {
+        $this->lastError = '';
+    }
 
     public function getId(): ?int
     {
@@ -202,5 +214,23 @@ class Mailbox implements MetaEntityInterface, ActivityRecordableInterface
         $this->folder = $folder;
 
         return $this;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    public function setLastError(string $lastError): self
+    {
+        $this->lastError = $lastError;
+        $this->lastErrorAt = Time::now();
+
+        return $this;
+    }
+
+    public function getLastErrorAt(): ?\DateTimeImmutable
+    {
+        return $this->lastErrorAt;
     }
 }

--- a/templates/mailboxes/index.html.twig
+++ b/templates/mailboxes/index.html.twig
@@ -43,30 +43,36 @@
 
             <ul class="list--padded list--border list--nostyle">
                 {% for mailbox in mailboxes %}
-                    <li class="row" data-test="mailbox-item">
-                        <span class="row__item--extend">
-                            {{ mailbox.name }}
-                        </span>
+                    <li class="flow flow--small" data-test="mailbox-item">
+                        <div class="row">
+                            <span class="row__item--extend">
+                                {{ mailbox.name }}
+                            </span>
 
-                        <div class="row__item--noshrink row row--always row--center flow flow--small">
-                            <form method="POST" action="{{ path('test mailbox', { uid: mailbox.uid }) }}">
-                                <input type="hidden" name="_csrf_token" value="{{ csrf_token('test mailbox') }}">
-                                <button type="submit" class="button--anchor">
-                                    {{ 'mailboxes.index.test_mailbox' | trans }}
-                                </button>
-                            </form>
+                            <div class="row__item--noshrink row row--always row--center flow flow--small">
+                                <form method="POST" action="{{ path('test mailbox', { uid: mailbox.uid }) }}">
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('test mailbox') }}">
+                                    <button type="submit" class="button--anchor">
+                                        {{ 'mailboxes.index.test_mailbox' | trans }}
+                                    </button>
+                                </form>
 
-                            <form method="POST" action="{{ path('delete mailbox', { uid: mailbox.uid }) }}">
-                                <input type="hidden" name="_csrf_token" value="{{ csrf_token('delete mailbox') }}">
-                                <button
-                                    type="submit"
-                                    class="button--anchor"
-                                    data-turbo-confirm="{{ 'mailboxes.index.delete.confirm' | trans }}"
-                                >
-                                    {{ 'mailboxes.index.delete' | trans }}
-                                </button>
-                            </form>
+                                <form method="POST" action="{{ path('delete mailbox', { uid: mailbox.uid }) }}">
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('delete mailbox') }}">
+                                    <button
+                                        type="submit"
+                                        class="button--anchor"
+                                        data-turbo-confirm="{{ 'mailboxes.index.delete.confirm' | trans }}"
+                                    >
+                                        {{ 'mailboxes.index.delete' | trans }}
+                                    </button>
+                                </form>
+                            </div>
                         </div>
+
+                        {% if mailbox.lastError %}
+                            {{ include('alerts/_error.html.twig', { message: mailbox.lastError }, with_context = false) }}
+                        {% endif %}
                     </li>
                 {% endfor %}
             </ul>

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -91,7 +91,6 @@ mailboxes.new.submit: 'Create the mailbox'
 mailboxes.new.title: 'New mailbox'
 mailboxes.password: Password
 mailboxes.port: 'Port IMAP'
-mailboxes.test.error: 'The connection failed: {error}'
 mailboxes.test.success: 'The connection works.'
 mailboxes.username: Username
 organizations.deletion.caution: Caution!

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -91,7 +91,6 @@ mailboxes.new.submit: 'Créer la boite mail'
 mailboxes.new.title: 'Nouvelle boite mail'
 mailboxes.password: 'Mot de passe'
 mailboxes.port: 'Port IMAP'
-mailboxes.test.error: "La connexion a échoué\_: {error}"
 mailboxes.test.success: 'La connexion fonctionne.'
 mailboxes.username: 'Nom d’utilisateur'
 organizations.deletion.caution: "Attention\_!"


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/331

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add fields `lastError` and `lastErrorAt` to `Mailbox
- set the errors during the test of the mailbox connection and when fetching mailboxes
- display the lastError in the list of mailboxes

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- configure a mailbox with wrong information (e.g. wrong port)
- click on "test connection" → check the error is displayed below the mailbox

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
