### PR TITLE
tec: Separate orga roles in user and tech roles

### DIFF
--- a/assets/javascripts/controllers/new_authorization_form_controller.js
+++ b/assets/javascripts/controllers/new_authorization_form_controller.js
@@ -25,8 +25,8 @@ export default class extends Controller {
         if (isOrgaChecked) {
             let selectedRole = '';
             this.roleOptionTargets.forEach((roleOption) => {
-                roleOption.hidden = roleOption.dataset.type !== 'orga';
-                if (roleOption.dataset.type === 'orga' && selectedRole === '') {
+                roleOption.hidden = !roleOption.dataset.type.startsWith('orga:');
+                if (roleOption.dataset.type.startsWith('orga:') && selectedRole === '') {
                     selectedRole = roleOption.value;
                 }
             });
@@ -35,8 +35,8 @@ export default class extends Controller {
         } else {
             let selectedRole = '';
             this.roleOptionTargets.forEach((roleOption) => {
-                roleOption.hidden = roleOption.dataset.type === 'orga';
-                if (roleOption.dataset.type !== 'orga' && selectedRole === '') {
+                roleOption.hidden = roleOption.dataset.type.startsWith('orga:');
+                if (!roleOption.dataset.type.startsWith('orga:') && selectedRole === '') {
                     selectedRole = roleOption.value;
                 }
             });

--- a/src/Command/SeedsCommand.php
+++ b/src/Command/SeedsCommand.php
@@ -54,7 +54,7 @@ class SeedsCommand extends Command
             'name' => 'Technician',
         ], [
             'description' => 'Solve problems.',
-            'type' => 'orga',
+            'type' => 'orga:tech',
             'permissions' => [
                 'orga:create:tickets',
                 'orga:create:tickets:messages',
@@ -74,7 +74,7 @@ class SeedsCommand extends Command
             'name' => 'User',
         ], [
             'description' => 'Have problems.',
-            'type' => 'orga',
+            'type' => 'orga:user',
             'permissions' => [
                 'orga:create:tickets',
                 'orga:create:tickets:messages',

--- a/src/Controller/Users/AuthorizationsController.php
+++ b/src/Controller/Users/AuthorizationsController.php
@@ -57,7 +57,7 @@ class AuthorizationsController extends BaseController
         $organizations = $organizationRepository->findAll();
         $organizations = $organizationSorter->asTree($organizations);
         $roles = $roleRepository->findBy([
-            'type' => ['orga', 'admin'],
+            'type' => ['orga:user', 'orga:tech', 'admin'],
         ]);
         if ($security->isGranted('admin:*')) {
             $superRole = $roleRepository->findOrCreateSuperRole();
@@ -94,7 +94,7 @@ class AuthorizationsController extends BaseController
         $organizations = $organizationSorter->asTree($organizations);
         $roles = $roleRepository->findAll();
         $roles = $roleRepository->findBy([
-            'type' => ['orga', 'admin'],
+            'type' => ['orga:user', 'orga:tech', 'admin'],
         ]);
         if ($security->isGranted('admin:*')) {
             $superRole = $roleRepository->findOrCreateSuperRole();

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -26,7 +26,7 @@ class Role implements MetaEntityInterface, ActivityRecordableInterface
 {
     use MetaEntityTrait;
 
-    public const TYPES = ['super', 'admin', 'orga'];
+    public const TYPES = ['super', 'admin', 'orga:tech', 'orga:user'];
 
     public const PERMISSIONS = [
         'admin:*',
@@ -180,9 +180,15 @@ class Role implements MetaEntityInterface, ActivityRecordableInterface
     {
         $sanitizedPermissions = [];
 
+        if ($type === 'orga:user' || $type === 'orga:tech') {
+            $prefix = 'orga';
+        } else {
+            $prefix = $type;
+        }
+
         foreach ($permissions as $permission) {
             if (
-                str_starts_with($permission, $type . ':') &&
+                str_starts_with($permission, $prefix . ':') &&
                 in_array($permission, self::PERMISSIONS) &&
                 $permission !== 'admin:*' // it is reserved to the super admin role
             ) {

--- a/src/Repository/AuthorizationRepository.php
+++ b/src/Repository/AuthorizationRepository.php
@@ -92,7 +92,7 @@ class AuthorizationRepository extends ServiceEntityRepository implements UidGene
                 JOIN a.role r
                 WHERE a.holder = :user
                 AND (a.organization IN (:orgaIds) OR a.organization IS NULL)
-                AND r.type = 'orga'
+                AND (r.type = 'orga:user' OR r.type = 'orga:tech')
             SQL);
             $query->setParameter('user', $user);
             $query->setParameter('orgaIds', $orgaIds);
@@ -122,7 +122,7 @@ class AuthorizationRepository extends ServiceEntityRepository implements UidGene
                 JOIN a.role r
                 WHERE a.holder = :user
                 AND a.organization IS NULL
-                AND r.type = 'orga'
+                AND (r.type = 'orga:user' OR r.type = 'orga:tech')
             SQL);
             $query->setParameter('user', $user);
 
@@ -143,7 +143,7 @@ class AuthorizationRepository extends ServiceEntityRepository implements UidGene
             FROM App\Entity\Authorization a
             JOIN a.role r
             WHERE a.holder = :user
-            AND r.type = 'orga'
+            AND (r.type = 'orga:user' OR r.type = 'orga:tech')
         SQL);
         $query->setParameter('user', $user);
 

--- a/templates/roles/_role_form.html.twig
+++ b/templates/roles/_role_form.html.twig
@@ -80,6 +80,40 @@
         />
     </div>
 
+    {% if type == 'admin' %}
+        <input type="hidden" name="type" value="admin">
+    {% else %}
+        <div class="row row--always flow">
+            <div>
+                <input
+                    type="radio"
+                    id="type-orga-user"
+                    name="type"
+                    value="orga:user"
+                    {{ type == 'orga:user' ? 'checked' }}
+                />
+
+                <label for="type-orga-user">
+                    {{ 'roles.type.orga.user' | trans }}
+                </label>
+            </div>
+
+            <div>
+                <input
+                    type="radio"
+                    id="type-orga-tech"
+                    name="type"
+                    value="orga:tech"
+                    {{ type == 'orga:tech' ? 'checked' }}
+                />
+
+                <label for="type-orga-tech">
+                    {{ 'roles.type.orga.tech' | trans }}
+                </label>
+            </div>
+        </div>
+    {% endif %}
+
     <fieldset class="flow" data-controller="checkboxes">
         <legend>{{ 'roles.permissions' | trans }}</legend>
 

--- a/templates/users/authorizations/index.html.twig
+++ b/templates/users/authorizations/index.html.twig
@@ -42,7 +42,7 @@
                         </div>
 
                         <div class="card__body flow flow--small text--center">
-                            {% if authorization.role.type == 'orga' %}
+                            {% if authorization.role.type == 'orga:tech' or authorization.role.type == 'orga:user' %}
                                 <div>
                                     <strong>
                                         {% if authorization.organization %}

--- a/tests/AuthorizationHelper.php
+++ b/tests/AuthorizationHelper.php
@@ -72,12 +72,12 @@ trait AuthorizationHelper
         /** @var \App\Repository\AuthorizationRepository $authorizationRepo */
         $authorizationRepo = $entityManager->getRepository(Authorization::class);
 
-        $permissions = Role::sanitizePermissions('orga', $permissions);
+        $permissions = Role::sanitizePermissions('orga:tech', $permissions);
 
         $role = new Role();
         $role->setName(Random::hex(10));
         $role->setDescription('The role description');
-        $role->setType('orga');
+        $role->setType('orga:tech');
         $role->setPermissions($permissions);
 
         $roleRepo->save($role);

--- a/tests/Controller/Users/AuthorizationsControllerTest.php
+++ b/tests/Controller/Users/AuthorizationsControllerTest.php
@@ -38,7 +38,7 @@ class AuthorizationsControllerTest extends WebTestCase
         ]);
         $roleB = RoleFactory::createOne([
             'name' => 'Role B',
-            'type' => 'orga',
+            'type' => 'orga:tech',
         ]);
         $orgaA = OrganizationFactory::createOne([
             'name' => 'Orga A',
@@ -159,7 +159,7 @@ class AuthorizationsControllerTest extends WebTestCase
         $this->grantAdmin($user->object(), ['admin:manage:users']);
         $holder = UserFactory::createOne();
         $role = RoleFactory::createOne([
-            'type' => 'orga',
+            'type' => 'orga:tech',
         ]);
         $organization = OrganizationFactory::createOne();
 
@@ -278,7 +278,7 @@ class AuthorizationsControllerTest extends WebTestCase
         $client->loginUser($user->object());
         $this->grantAdmin($user->object(), ['admin:manage:users']);
         $role = RoleFactory::createOne([
-            'type' => 'orga',
+            'type' => 'orga:tech',
         ]);
         $organization = OrganizationFactory::createOne();
         $this->grantOrga($user->object(), ['orga:see'], $organization->object());

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -151,6 +151,8 @@ roles.super_admin: Super-admin
 roles.super_admin.description: 'A special role with an access to all the administration (cannot be modified).'
 roles.type.admin: 'Admin role'
 roles.type.orga: 'Orga role'
+roles.type.orga.tech: 'Technician role'
+roles.type.orga.user: 'User role'
 settings.index.no_access: 'You don’t have access to the administration.'
 settings.index.no_access_advice: 'Your admin role has probably no permissions. You should contact another administrator to fix this.'
 settings.index.title: Settings

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -151,6 +151,8 @@ roles.super_admin: Super-admin
 roles.super_admin.description: 'Un rôle spécial avec un accès à toute l’administration (ne peut pas être modifié).'
 roles.type.admin: 'Rôle admin'
 roles.type.orga: 'Rôle orga'
+roles.type.orga.tech: 'Rôle technicien'
+roles.type.orga.user: 'Rôle utilisateur'
 settings.index.no_access: 'Vous n’avez pas accès à l’administration.'
 settings.index.no_access_advice: 'Votre rôle admin n’a probablement aucune permission. Vous devriez contacter un autre administrateur pour corriger cela.'
 settings.index.title: Gestion


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/273
https://github.com/Probesys/bileto/issues/147

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- split the Role type `orga` in `orga:user` and `orga:tech`
- adapt the rest of the code to use these new types
- add radio buttons to the roles form to allow to select the orga type

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- create a new role → check you can select either "user" or "tech"
- edit a role → check you can change the type

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
