### PR TITLE
imp: Display only tech users in lists of assignees

### DIFF
--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -107,7 +107,8 @@ class TicketsController extends BaseController
     ): Response {
         $this->denyAccessUnlessGranted('orga:create:tickets', $organization);
 
-        $users = $actorsLister->findAllForOrganization($organization);
+        $allUsers = $actorsLister->findAllForOrganization($organization);
+        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
 
         return $this->render('organizations/tickets/new.html.twig', [
             'organization' => $organization,
@@ -120,7 +121,8 @@ class TicketsController extends BaseController
             'urgency' => Ticket::DEFAULT_WEIGHT,
             'impact' => Ticket::DEFAULT_WEIGHT,
             'priority' => Ticket::DEFAULT_WEIGHT,
-            'users' => $users,
+            'allUsers' => $allUsers,
+            'techUsers' => $techUsers,
         ]);
     }
 
@@ -192,7 +194,8 @@ class TicketsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $users = $actorsLister->findAllForOrganization($organization);
+        $allUsers = $actorsLister->findAllForOrganization($organization);
+        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
 
         if (!$this->isCsrfTokenValid('create organization ticket', $csrfToken)) {
             return $this->renderBadRequest('organizations/tickets/new.html.twig', [
@@ -206,7 +209,8 @@ class TicketsController extends BaseController
                 'urgency' => $urgency,
                 'impact' => $impact,
                 'priority' => $priority,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'error' => $translator->trans('csrf.invalid', [], 'errors'),
             ]);
         }
@@ -224,7 +228,8 @@ class TicketsController extends BaseController
                 'urgency' => $urgency,
                 'impact' => $impact,
                 'priority' => $priority,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'errors' => [
                     'requester' => $translator->trans('ticket.requester.invalid', [], 'errors'),
                 ],
@@ -245,7 +250,8 @@ class TicketsController extends BaseController
                     'urgency' => $urgency,
                     'impact' => $impact,
                     'priority' => $priority,
-                    'users' => $users,
+                    'allUsers' => $allUsers,
+                    'techUsers' => $techUsers,
                     'errors' => [
                         'assignee' => $translator->trans('ticket.assignee.invalid', [], 'errors'),
                     ],
@@ -288,7 +294,8 @@ class TicketsController extends BaseController
                 'urgency' => $urgency,
                 'impact' => $impact,
                 'priority' => $priority,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'errors' => $this->formatErrors($errors),
             ]);
         }
@@ -312,7 +319,8 @@ class TicketsController extends BaseController
                 'urgency' => $urgency,
                 'impact' => $impact,
                 'priority' => $priority,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'errors' => $this->formatErrors($errors),
             ]);
         }

--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -107,8 +107,8 @@ class TicketsController extends BaseController
     ): Response {
         $this->denyAccessUnlessGranted('orga:create:tickets', $organization);
 
-        $allUsers = $actorsLister->findAllForOrganization($organization);
-        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
+        $allUsers = $actorsLister->findByOrganization($organization);
+        $techUsers = $actorsLister->findByOrganization($organization, role: 'tech');
 
         return $this->render('organizations/tickets/new.html.twig', [
             'organization' => $organization,
@@ -194,8 +194,8 @@ class TicketsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $allUsers = $actorsLister->findAllForOrganization($organization);
-        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
+        $allUsers = $actorsLister->findByOrganization($organization);
+        $techUsers = $actorsLister->findByOrganization($organization, role: 'tech');
 
         if (!$this->isCsrfTokenValid('create organization ticket', $csrfToken)) {
             return $this->renderBadRequest('organizations/tickets/new.html.twig', [

--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -107,7 +107,7 @@ class TicketsController extends BaseController
     ): Response {
         $this->denyAccessUnlessGranted('orga:create:tickets', $organization);
 
-        $users = $actorsLister->listUsers();
+        $users = $actorsLister->findAllForOrganization($organization);
 
         return $this->render('organizations/tickets/new.html.twig', [
             'organization' => $organization,
@@ -192,7 +192,7 @@ class TicketsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $users = $actorsLister->listUsers();
+        $users = $actorsLister->findAllForOrganization($organization);
 
         if (!$this->isCsrfTokenValid('create organization ticket', $csrfToken)) {
             return $this->renderBadRequest('organizations/tickets/new.html.twig', [

--- a/src/Controller/Tickets/ActorsController.php
+++ b/src/Controller/Tickets/ActorsController.php
@@ -33,7 +33,8 @@ class ActorsController extends BaseController
             $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
         }
 
-        $users = $actorsLister->findAllForOrganization($organization);
+        $allUsers = $actorsLister->findAllForOrganization($organization);
+        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
         $requester = $ticket->getRequester();
         $assignee = $ticket->getAssignee();
 
@@ -41,7 +42,8 @@ class ActorsController extends BaseController
             'ticket' => $ticket,
             'requesterUid' => $requester ? $requester->getUid() : '',
             'assigneeUid' => $assignee ? $assignee->getUid() : '',
-            'users' => $users,
+            'allUsers' => $allUsers,
+            'techUsers' => $techUsers,
         ]);
     }
 
@@ -76,14 +78,16 @@ class ActorsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $users = $actorsLister->findAllForOrganization($organization);
+        $allUsers = $actorsLister->findAllForOrganization($organization);
+        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
 
         if (!$this->isCsrfTokenValid('update ticket actors', $csrfToken)) {
             return $this->renderBadRequest('tickets/actors/edit.html.twig', [
                 'ticket' => $ticket,
                 'requesterUid' => $requesterUid,
                 'assigneeUid' => $assigneeUid,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'error' => $translator->trans('csrf.invalid', [], 'errors'),
             ]);
         }
@@ -94,7 +98,8 @@ class ActorsController extends BaseController
                 'ticket' => $ticket,
                 'requesterUid' => $requesterUid,
                 'assigneeUid' => $assigneeUid,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'errors' => [
                     'requester' => $translator->trans('ticket.requester.invalid', [], 'errors'),
                 ],
@@ -108,7 +113,8 @@ class ActorsController extends BaseController
                     'ticket' => $ticket,
                     'requesterUid' => $requesterUid,
                     'assigneeUid' => $assigneeUid,
-                    'users' => $users,
+                    'allUsers' => $allUsers,
+                    'techUsers' => $techUsers,
                     'errors' => [
                         'assignee' => $translator->trans('ticket.assignee.invalid', [], 'errors'),
                     ],

--- a/src/Controller/Tickets/ActorsController.php
+++ b/src/Controller/Tickets/ActorsController.php
@@ -33,7 +33,7 @@ class ActorsController extends BaseController
             $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
         }
 
-        $users = $actorsLister->listUsers();
+        $users = $actorsLister->findAllForOrganization($organization);
         $requester = $ticket->getRequester();
         $assignee = $ticket->getAssignee();
 
@@ -76,7 +76,7 @@ class ActorsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $users = $actorsLister->listUsers();
+        $users = $actorsLister->findAllForOrganization($organization);
 
         if (!$this->isCsrfTokenValid('update ticket actors', $csrfToken)) {
             return $this->renderBadRequest('tickets/actors/edit.html.twig', [

--- a/src/Controller/Tickets/ActorsController.php
+++ b/src/Controller/Tickets/ActorsController.php
@@ -33,8 +33,8 @@ class ActorsController extends BaseController
             $this->denyAccessUnlessGranted('orga:see:tickets:all', $organization);
         }
 
-        $allUsers = $actorsLister->findAllForOrganization($organization);
-        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
+        $allUsers = $actorsLister->findByOrganization($organization);
+        $techUsers = $actorsLister->findByOrganization($organization, role: 'tech');
         $requester = $ticket->getRequester();
         $assignee = $ticket->getAssignee();
 
@@ -78,8 +78,8 @@ class ActorsController extends BaseController
         /** @var string $csrfToken */
         $csrfToken = $request->request->get('_csrf_token', '');
 
-        $allUsers = $actorsLister->findAllForOrganization($organization);
-        $techUsers = $actorsLister->findAllForOrganization($organization, role: 'tech');
+        $allUsers = $actorsLister->findByOrganization($organization);
+        $techUsers = $actorsLister->findByOrganization($organization, role: 'tech');
 
         if (!$this->isCsrfTokenValid('update ticket actors', $csrfToken)) {
             return $this->renderBadRequest('tickets/actors/edit.html.twig', [

--- a/src/Controller/Tickets/FiltersController.php
+++ b/src/Controller/Tickets/FiltersController.php
@@ -66,7 +66,7 @@ class FiltersController extends BaseController
                 'from' => $from,
             ]);
         } elseif ($filter === 'actors' || $filter === 'assignee' || $filter === 'requester' || $filter === 'involves') {
-            $users = $actorsLister->listUsers();
+            $users = $actorsLister->findAll();
             return $this->render("tickets/filters/edit_actors.html.twig", [
                 'ticketFilter' => $ticketFilter,
                 'users' => $users,

--- a/src/Controller/Tickets/FiltersController.php
+++ b/src/Controller/Tickets/FiltersController.php
@@ -66,10 +66,12 @@ class FiltersController extends BaseController
                 'from' => $from,
             ]);
         } elseif ($filter === 'actors' || $filter === 'assignee' || $filter === 'requester' || $filter === 'involves') {
-            $users = $actorsLister->findAll();
+            $allUsers = $actorsLister->findAll();
+            $techUsers = $actorsLister->findAll(role: 'tech');
             return $this->render("tickets/filters/edit_actors.html.twig", [
                 'ticketFilter' => $ticketFilter,
-                'users' => $users,
+                'allUsers' => $allUsers,
+                'techUsers' => $techUsers,
                 'query' => $textualQuery,
                 'from' => $from,
             ]);

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -6,6 +6,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Organization;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -68,6 +69,29 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             OR LOWER(u.email) LIKE :value
         SQL);
         $query->setParameter('value', "%{$value}%");
+
+        return $query->getResult();
+    }
+
+    /**
+     * @param int[] $orgaIds
+     *
+     * @return User[]
+     */
+    public function findByOrganizationIds(array $orgaIds): array
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT u
+            FROM App\Entity\User u
+            JOIN u.authorizations a
+            JOIN a.role r
+            WHERE (a.organization IN (:organizations) OR a.organization IS NULL)
+            AND (r.type = 'orga:user' OR r.type = 'orga:tech')
+        SQL);
+
+        $query->setParameter('organizations', $orgaIds);
 
         return $query->getResult();
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -75,10 +75,11 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
 
     /**
      * @param int[] $orgaIds
+     * @param 'any'|'user'|'tech' $role
      *
      * @return User[]
      */
-    public function findByOrganizationIds(array $orgaIds): array
+    public function findByOrganizationIds(array $orgaIds, string $role = 'any'): array
     {
         $entityManager = $this->getEntityManager();
 
@@ -88,10 +89,19 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             JOIN u.authorizations a
             JOIN a.role r
             WHERE (a.organization IN (:organizations) OR a.organization IS NULL)
-            AND (r.type = 'orga:user' OR r.type = 'orga:tech')
+            AND r.type IN (:types)
         SQL);
 
+        if ($role === 'user') {
+            $types = ['orga:user'];
+        } elseif ($role === 'tech') {
+            $types = ['orga:tech'];
+        } else {
+            $types = ['orga:user', 'orga:tech'];
+        }
+
         $query->setParameter('organizations', $orgaIds);
+        $query->setParameter('types', $types);
 
         return $query->getResult();
     }

--- a/src/Service/ActorsLister.php
+++ b/src/Service/ActorsLister.php
@@ -26,9 +26,11 @@ class ActorsLister
     }
 
     /**
+     * @param 'any'|'user'|'tech' $role
+     *
      * @return User[]
      */
-    public function findAllForOrganization(Organization $organization): array
+    public function findAllForOrganization(Organization $organization, string $role = 'any'): array
     {
         $currentUser = $this->security->getUser();
 
@@ -39,7 +41,7 @@ class ActorsLister
 
         $orgaIds = array_intersect($authorizedOrgaIds, $orgaIds);
 
-        $users = $this->userRepository->findByOrganizationIds($orgaIds);
+        $users = $this->userRepository->findByOrganizationIds($orgaIds, $role);
 
         $this->userSorter->sort($users);
 
@@ -55,15 +57,17 @@ class ActorsLister
     }
 
     /**
+     * @param 'any'|'user'|'tech' $role
+     *
      * @return User[]
      */
-    public function findAll(): array
+    public function findAll(string $role = 'any'): array
     {
         $currentUser = $this->security->getUser();
 
         $authorizedOrgaIds = $this->findAuthorizedOrganizationIds($currentUser);
 
-        $users = $this->userRepository->findByOrganizationIds($authorizedOrgaIds);
+        $users = $this->userRepository->findByOrganizationIds($authorizedOrgaIds, $role);
 
         $this->userSorter->sort($users);
 

--- a/src/Service/ActorsLister.php
+++ b/src/Service/ActorsLister.php
@@ -8,18 +8,16 @@ namespace App\Service;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
+use App\Service\UserSorter;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class ActorsLister
 {
-    private UserRepository $userRepository;
-
-    private Security $security;
-
-    public function __construct(UserRepository $userRepository, Security $security)
-    {
-        $this->userRepository = $userRepository;
-        $this->security = $security;
+    public function __construct(
+        private UserRepository $userRepository,
+        private UserSorter $userSorter,
+        private Security $security,
+    ) {
     }
 
     /**
@@ -28,10 +26,13 @@ class ActorsLister
     public function listUsers(): array
     {
         $currentUser = $this->security->getUser();
-        $users = $this->userRepository->findBy([], ['email' => 'ASC']);
+        $users = $this->userRepository->findAll();
+
+        $this->userSorter->sort($users);
 
         $currentUserKey = array_search($currentUser, $users);
         if ($currentUserKey !== false) {
+            // Make sure that the current user is first in the list
             $user = $users[$currentUserKey];
             unset($users[$currentUserKey]);
             return array_merge([$user], $users);

--- a/src/Service/ActorsLister.php
+++ b/src/Service/ActorsLister.php
@@ -8,6 +8,8 @@ namespace App\Service;
 
 use App\Entity\Organization;
 use App\Entity\User;
+use App\Repository\AuthorizationRepository;
+use App\Repository\OrganizationRepository;
 use App\Repository\UserRepository;
 use App\Service\UserSorter;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -15,6 +17,8 @@ use Symfony\Bundle\SecurityBundle\Security;
 class ActorsLister
 {
     public function __construct(
+        private AuthorizationRepository $authRepository,
+        private OrganizationRepository $orgaRepository,
         private UserRepository $userRepository,
         private UserSorter $userSorter,
         private Security $security,
@@ -28,8 +32,12 @@ class ActorsLister
     {
         $currentUser = $this->security->getUser();
 
+        $authorizedOrgaIds = $this->findAuthorizedOrganizationIds($currentUser);
+
         $orgaIds = $organization->getParentOrganizationIds();
         $orgaIds[] = $organization->getId();
+
+        $orgaIds = array_intersect($authorizedOrgaIds, $orgaIds);
 
         $users = $this->userRepository->findByOrganizationIds($orgaIds);
 
@@ -53,7 +61,9 @@ class ActorsLister
     {
         $currentUser = $this->security->getUser();
 
-        $users = $this->userRepository->findAll();
+        $authorizedOrgaIds = $this->findAuthorizedOrganizationIds($currentUser);
+
+        $users = $this->userRepository->findByOrganizationIds($authorizedOrgaIds);
 
         $this->userSorter->sort($users);
 
@@ -66,5 +76,22 @@ class ActorsLister
         } else {
             return $users;
         }
+    }
+
+    /**
+     * @return int[]
+     */
+    private function findAuthorizedOrganizationIds(User $currentUser): array
+    {
+        $orgaIds = $this->authRepository->getAuthorizedOrganizationIds($currentUser);
+        if (in_array(null, $orgaIds)) {
+            $organizations = $this->orgaRepository->findAll();
+        } else {
+            $organizations = $this->orgaRepository->findWithSubOrganizations($orgaIds);
+        }
+
+        return array_map(function ($orga) {
+            return $orga->getId();
+        }, $organizations);
     }
 }

--- a/templates/organizations/tickets/new.html.twig
+++ b/templates/organizations/tickets/new.html.twig
@@ -157,7 +157,7 @@
                                 aria-errormessage="requester-error"
                             {% endif %}
                         >
-                            {% for user in users %}
+                            {% for user in allUsers %}
                                 <option value="{{ user.uid }}" {{ user.uid == requesterUid ? 'selected' }}>
                                     {{ user.displayName }}
 
@@ -198,7 +198,7 @@
                                 {{ 'tickets.unassigned' | trans }}
                             </option>
 
-                            {% for user in users %}
+                            {% for user in techUsers %}
                                 <option value="{{ user.uid }}" {{ user.uid == assigneeUid ? 'selected' }}>
                                     {{ user.displayName }}
 

--- a/templates/tickets/actors/edit.html.twig
+++ b/templates/tickets/actors/edit.html.twig
@@ -44,7 +44,7 @@
                     aria-errormessage="requester-error"
                 {% endif %}
             >
-                {% for user in users %}
+                {% for user in allUsers %}
                     <option value="{{ user.uid }}" {{ user.uid == requesterUid ? 'selected' }}>
                         {{ user.displayName }}
 
@@ -85,7 +85,7 @@
                     {{ 'tickets.unassigned' | trans }}
                 </option>
 
-                {% for user in users %}
+                {% for user in techUsers %}
                     <option value="{{ user.uid }}" {{ user.uid == assigneeUid ? 'selected' }}>
                         {{ user.displayName }}
 

--- a/templates/tickets/filters/edit_actors.html.twig
+++ b/templates/tickets/filters/edit_actors.html.twig
@@ -26,7 +26,7 @@
             {{ include(
                 'tickets/filters/_multiselect_actors.html.twig',
                 {
-                    users: users,
+                    users: allUsers,
                     selected: ticketFilter.filter('involves'),
                     id: "filter-involves",
                     name: "filters[involves][]",
@@ -60,7 +60,7 @@
             {{ include(
                 'tickets/filters/_multiselect_actors.html.twig',
                 {
-                    users: users,
+                    users: techUsers,
                     selected: ticketFilter.filter('assignee'),
                     id: "filter-assignee",
                     name: "filters[assignee][]",
@@ -77,7 +77,7 @@
             {{ include(
                 'tickets/filters/_multiselect_actors.html.twig',
                 {
-                    users: users,
+                    users: allUsers,
                     selected: ticketFilter.filter('requester'),
                     id: "filter-requester",
                     name: "filters[requester][]",

--- a/tests/Controller/Organizations/TicketsControllerTest.php
+++ b/tests/Controller/Organizations/TicketsControllerTest.php
@@ -210,8 +210,8 @@ class TicketsControllerTest extends WebTestCase
         $this->assertSame(0, TicketFactory::count());
         $this->assertSame(0, MessageFactory::count());
 
-        $client->request('GET', "/organizations/{$organization->getUid()}/tickets/new");
-        $crawler = $client->submitForm('form-create-ticket-submit', [
+        $client->request('POST', "/organizations/{$organization->getUid()}/tickets/new", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'create organization ticket'),
             'title' => $title,
             'requesterUid' => $requester->getUid(),
             'assigneeUid' => $assignee->getUid(),

--- a/tests/Controller/Tickets/ActorsControllerTest.php
+++ b/tests/Controller/Tickets/ActorsControllerTest.php
@@ -102,8 +102,8 @@ class ActorsControllerTest extends WebTestCase
             'assignee' => null,
         ]);
 
-        $client->request('GET', "/tickets/{$ticket->getUid()}/actors/edit");
-        $crawler = $client->submitForm('form-update-actors-submit', [
+        $client->request('POST', "/tickets/{$ticket->getUid()}/actors/edit", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'update ticket actors'),
             'requesterUid' => $requester->getUid(),
             'assigneeUid' => $assignee->getUid(),
         ]);

--- a/tests/Service/ActorsListerTest.php
+++ b/tests/Service/ActorsListerTest.php
@@ -1,0 +1,321 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Repository\AuthorizationRepository;
+use App\Service\ActorsLister;
+use App\Tests\AuthorizationHelper;
+use App\Tests\Factory\AuthorizationFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\RoleFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class ActorsListerTest extends WebTestCase
+{
+    use AuthorizationHelper;
+    use Factories;
+    use ResetDatabase;
+
+    private ActorsLister $actorsLister;
+
+    private User $currentUser;
+
+    private AuthorizationRepository $authRepository;
+
+    /**
+     * @before
+     */
+    public function setupTest(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        /** @var ActorsLister */
+        $actorsLister = $container->get(ActorsLister::class);
+        $this->actorsLister = $actorsLister;
+
+        $this->currentUser = UserFactory::createOne()->object();
+        $client->loginUser($this->currentUser);
+
+        /** @var \Zenstruck\Foundry\RepositoryProxy<AuthorizationRepository> */
+        $authRepositoryProxy = AuthorizationFactory::repository();
+        /** @var AuthorizationRepository */
+        $authRepository = $authRepositoryProxy->inner();
+        $this->authRepository = $authRepository;
+    }
+
+    public function testFindAll(): void
+    {
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        // The current user must have an authorization on the users'
+        // organizations that we want to list.
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            null,
+        );
+        // The listed users must have authorizations on some organizations
+        // themselves. Otherwise, they are not part of any organization and we
+        // don't want to list them.
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            null,
+        );
+
+        $users = $this->actorsLister->findAll();
+
+        $this->assertSame(2, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindAllListsUsersInSubOrganizations(): void
+    {
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        $organization = OrganizationFactory::createOne();
+        $subOrganization = OrganizationFactory::createOne([
+            'parentsPath' => "/{$organization->getId()}/",
+        ]);
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $organization->object(),
+        );
+        // Both users are not in the same organization, but the $otherUser is
+        // in a sub-organization of the one of the current user.
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $subOrganization->object(),
+        );
+
+        $users = $this->actorsLister->findAll();
+
+        $this->assertSame(2, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindAllDoesNotListUsersInNotAuthorizedOrganization(): void
+    {
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        $organization = OrganizationFactory::createOne();
+        $otherOrga = OrganizationFactory::createOne();
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $organization->object(),
+        );
+        // The $otherUser is now in a totally separated organization.
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $otherOrga->object(),
+        );
+
+        $users = $this->actorsLister->findAll();
+
+        $this->assertSame(1, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertNotContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindAllOnlyListsUsersOfTheGivenRole(): void
+    {
+        $otherUser = UserFactory::createOne();
+        $roleUser = RoleFactory::createOne([
+            'type' => 'orga:user',
+        ]);
+        $roleTech = RoleFactory::createOne([
+            'type' => 'orga:tech',
+        ]);
+        // $currentUser has a "tech" role
+        $this->authRepository->grant(
+            $this->currentUser,
+            $roleTech->object(),
+            null,
+        );
+        // $otherUser has a "user" role
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $roleUser->object(),
+            null,
+        );
+
+        // and we ask for tech actors only
+        $users = $this->actorsLister->findAll(role: 'tech');
+
+        $this->assertSame(1, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertNotContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindByOrganization(): void
+    {
+        $organization = OrganizationFactory::createOne();
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        // The $currentUser must have an authorization on the requested
+        // organization.
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $organization->object(),
+        );
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $organization->object(),
+        );
+
+        $users = $this->actorsLister->findByOrganization($organization->object());
+
+        $this->assertSame(2, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindByOrganizationOnlyListsUsersOfTheGivenRole(): void
+    {
+        $organization = OrganizationFactory::createOne();
+        $otherUser = UserFactory::createOne();
+        $roleUser = RoleFactory::createOne([
+            'type' => 'orga:user',
+        ]);
+        $roleTech = RoleFactory::createOne([
+            'type' => 'orga:tech',
+        ]);
+        $this->authRepository->grant(
+            $this->currentUser,
+            $roleTech->object(),
+            $organization->object(),
+        );
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $roleUser->object(),
+            $organization->object(),
+        );
+
+        $users = $this->actorsLister->findByOrganization($organization->object(), role: 'user');
+
+        $this->assertSame(1, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertNotContains($this->currentUser->getId(), $userIds);
+        $this->assertContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindByOrganizationListsUsersInParentOrganizations(): void
+    {
+        $organization = OrganizationFactory::createOne();
+        $subOrganization = OrganizationFactory::createOne([
+            'parentsPath' => "/{$organization->getId()}/",
+        ]);
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        // $currentUser is in the parent organization
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $organization->object(),
+        );
+        // $otherUser is in the sub-organization
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $subOrganization->object(),
+        );
+
+        // and we ask for the users of the sub-organization
+        $users = $this->actorsLister->findByOrganization($subOrganization->object());
+
+        // but both users are returned!
+        $this->assertSame(2, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertContains($otherUser->getId(), $userIds);
+    }
+
+    public function testFindByOrganizationDoesNotListUsersIfNotAuthorized(): void
+    {
+        $organization = OrganizationFactory::createOne();
+        $otherOrganization = OrganizationFactory::createOne();
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $organization->object(),
+        );
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $otherOrganization->object(),
+        );
+
+        $users = $this->actorsLister->findByOrganization($otherOrganization->object());
+
+        $this->assertSame(0, count($users));
+    }
+
+    public function testFindByOrganizationDoesNotListUsersInParentOrganizationsIfNotAuthorized(): void
+    {
+        $organization = OrganizationFactory::createOne();
+        $subOrganization = OrganizationFactory::createOne([
+            'parentsPath' => "/{$organization->getId()}/",
+        ]);
+        $otherUser = UserFactory::createOne();
+        $role = RoleFactory::createOne([
+            'type' => RoleFactory::faker()->randomElement(['orga:tech', 'orga:user']),
+        ]);
+        // This time, $currentUser is in the sub-organization
+        $this->authRepository->grant(
+            $this->currentUser,
+            $role->object(),
+            $subOrganization->object(),
+        );
+        // While $otherUser is in the parent organization
+        $this->authRepository->grant(
+            $otherUser->object(),
+            $role->object(),
+            $organization->object(),
+        );
+
+        // And we ask for the users of the sub-organization
+        $users = $this->actorsLister->findByOrganization($subOrganization->object());
+
+        // Only the user from the sub-organization is returned as current user
+        // isn't authorized in the parent organization
+        $this->assertSame(1, count($users));
+        $userIds = array_map(fn ($user) => $user->getId(), $users);
+        $this->assertContains($this->currentUser->getId(), $userIds);
+        $this->assertNotContains($otherUser->getId(), $userIds);
+    }
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/273

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- use the UsersSorter in the ActorsLister
- limit the actors lists to the users of the current organization
- limit the actors lists to the users of the accessible organizations
- allow to list users with either "user", "tech" or both roles

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- open the lists of requesters (new ticket, edit actors and filter actors) → check only users of the current organization are listed
- open the lists of assignees (new ticket, edit actors and filter actors) → check only **tech** users of the current organization are listed

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
