### PR TITLE
fix: Don't try to send email if $recipients is empty

### DIFF
--- a/src/MessageHandler/SendMessageEmailHandler.php
+++ b/src/MessageHandler/SendMessageEmailHandler.php
@@ -60,6 +60,10 @@ class SendMessageEmailHandler
 
         $recipients = array_unique($recipients);
 
+        if (empty($recipients)) {
+            return;
+        }
+
         $subject = "Re: [#{$ticket->getId()}] {$ticket->getTitle()}";
 
         $email = new Email();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/330

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- return early when there is no recipient in email the notification system

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- create a new ticket by email
- check in the logs of the worker that the `SendMessageEmail` message is handled successfully

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
