### PR TITLE
new: Allow to delete a mailbox email in error

### DIFF
--- a/src/Controller/MailboxEmailsController.php
+++ b/src/Controller/MailboxEmailsController.php
@@ -1,0 +1,39 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Controller;
+
+use App\Entity\MailboxEmail;
+use App\Repository\MailboxEmailRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class MailboxEmailsController extends BaseController
+{
+    #[Route('/mailbox-emails/{uid}/deletion', name: 'delete mailbox email', methods: ['POST'])]
+    public function delete(
+        MailboxEmail $mailboxEmail,
+        Request $request,
+        MailboxEmailRepository $mailboxEmailRepository,
+        TranslatorInterface $translator,
+    ): Response {
+        $this->denyAccessUnlessGranted('admin:manage:mailboxes');
+
+        /** @var string $csrfToken */
+        $csrfToken = $request->request->get('_csrf_token', '');
+
+        if (!$this->isCsrfTokenValid('delete mailbox email', $csrfToken)) {
+            $this->addFlash('error', $translator->trans('csrf.invalid', [], 'errors'));
+            return $this->redirectToRoute('mailboxes');
+        }
+
+        $mailboxEmailRepository->remove($mailboxEmail, true);
+
+        return $this->redirectToRoute('mailboxes');
+    }
+}

--- a/templates/mailboxes/index.html.twig
+++ b/templates/mailboxes/index.html.twig
@@ -80,9 +80,13 @@
             {% if errorMailboxEmails %}
                 <h2>{{ 'mailboxes.index.emails.title' | trans }}</h2>
 
+                <p class="text--secondary">
+                    {{ 'mailboxes.index.emails.desc' | trans }}
+                </p>
+
                 <ul class="list--padded list--border list--nostyle">
                     {% for mailboxEmail in errorMailboxEmails %}
-                        <li class="flow flow--small" data-test="mailbox-email-item">
+                        <li class="flow" data-test="mailbox-email-item">
                             <div class="row flow">
                                 <span class="row__item--extend">
                                     {{ mailboxEmail.subject }}
@@ -99,10 +103,23 @@
                                 </span>
                             </div>
 
-                            <p class="text--error">
-                                {{ 'mailboxes.index.emails.error' | trans }}
-                                {{ mailboxEmail.lastError }}
-                            </p>
+                            <div class="row flow">
+                                <p class="row__item--extend text--error">
+                                    {{ 'mailboxes.index.emails.error' | trans }}
+                                    {{ mailboxEmail.lastError }}
+                                </p>
+
+                                <form method="POST" action="{{ path('delete mailbox email', { uid: mailboxEmail.uid }) }}">
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('delete mailbox email') }}">
+                                    <button
+                                        type="submit"
+                                        class="button--anchor"
+                                        data-turbo-confirm="{{ 'mailboxes.index.emails.delete.confirm' | trans }}"
+                                    >
+                                        {{ 'mailboxes.index.emails.delete' | trans }}
+                                    </button>
+                                </form>
+                            </div>
                         </li>
                     {% endfor %}
                 </ul>

--- a/tests/Controller/MailboxEmailsControllerTest.php
+++ b/tests/Controller/MailboxEmailsControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Controller;
+
+use App\Tests\AuthorizationHelper;
+use App\Tests\Factory\MailboxEmailFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class MailboxEmailsControllerTest extends WebTestCase
+{
+    use AuthorizationHelper;
+    use Factories;
+    use ResetDatabase;
+    use SessionHelper;
+
+    public function testPostDeleteRemovesTheMailboxEmailAndRedirects(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantAdmin($user->object(), ['admin:manage:mailboxes']);
+        $mailboxEmail = MailboxEmailFactory::createOne();
+
+        $client->request('POST', "/mailbox-emails/{$mailboxEmail->getUid()}/deletion", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'delete mailbox email'),
+        ]);
+
+        $this->assertResponseRedirects('/mailboxes', 302);
+        MailboxEmailFactory::assert()->notExists(['id' => $mailboxEmail->getId()]);
+    }
+
+    public function testPostDeleteFailsIfCsrfTokenIsInvalid(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $this->grantAdmin($user->object(), ['admin:manage:mailboxes']);
+        $mailboxEmail = MailboxEmailFactory::createOne();
+
+        $client->request('POST', "/mailbox-emails/{$mailboxEmail->getUid()}/deletion", [
+            '_csrf_token' => 'not the token',
+        ]);
+
+        $this->assertResponseRedirects('/mailboxes', 302);
+        $client->followRedirect();
+        $this->assertSelectorTextContains('#notifications', 'The security token is invalid');
+        MailboxEmailFactory::assert()->exists(['id' => $mailboxEmail->getId()]);
+    }
+
+    public function testPostDeleteFailsIfAccessIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->object());
+        $mailboxEmail = MailboxEmailFactory::createOne();
+
+        $client->catchExceptions(false);
+        $client->request('POST', "/mailbox-emails/{$mailboxEmail->getUid()}/deletion", [
+            '_csrf_token' => $this->generateCsrfToken($client, 'delete mailbox email'),
+        ]);
+    }
+}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -80,6 +80,9 @@ mailboxes.encryption.tls: TLS
 mailboxes.folder: Folder
 mailboxes.host: Hostname
 mailboxes.index.collect: 'Collect the mailboxes'
+mailboxes.index.emails.delete: Delete
+mailboxes.index.emails.delete.confirm: 'Are you sure that you want to delete this email?'
+mailboxes.index.emails.desc: 'Once you fix the errors, these emails will automatically be processed again. Otherwise, you can delete them.'
 mailboxes.index.emails.error: 'Error:'
 mailboxes.index.emails.title: 'Emails in error'
 mailboxes.index.delete: Delete

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -80,6 +80,9 @@ mailboxes.encryption.tls: TLS
 mailboxes.folder: Répertoire
 mailboxes.host: 'Nom d’hôte'
 mailboxes.index.collect: 'Collecter les boites'
+mailboxes.index.emails.delete: Supprimer
+mailboxes.index.emails.delete.confirm: "Êtes-vous sûr de vouloir supprimer cet email\_?"
+mailboxes.index.emails.desc: 'Une fois leurs erreurs corrigées, ces emails seront traités à nouveau. Vous pouvez également les supprimer.'
 mailboxes.index.emails.error: "Erreur\_:"
 mailboxes.index.emails.title: 'Emails en erreur'
 mailboxes.index.delete: Supprimer


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/331

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add a controller to delete mailbox emails
- add a link-button to delete mailbox emails in error on the mailboxes page

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- send an email with an unknown sender
- collect the emails
- delete the email appearing on the page → check that the email disappears

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
