### PR TITLE
tec: Improve starting a MariaDB database in dev

### DIFF
--- a/.env
+++ b/.env
@@ -8,8 +8,8 @@ APP_SECRET=97cb420d0d43c4c786c51225db0b6018
 
 # URL to connect to the database.
 # Uncomment one of the two following line (depending on your database) and adapt the credentials.
-DATABASE_URL="postgresql://postgres:postgres@database:5432/bileto?serverVersion=11&charset=utf8"
-# DATABASE_URL="mysql://root:mariadb@database:3306/bileto?serverVersion=10.4.29-MariaDB"
+DATABASE_URL="postgresql://postgres:postgres@pgsql:5432/bileto?serverVersion=11&charset=utf8"
+# DATABASE_URL="mysql://root:mariadb@mariadb:3306/bileto?serverVersion=10.4.29-MariaDB"
 
 # Configure your mail server. It is used to send email notifications to the users.
 # Uncomment both MAILER_* lines and set them to your needs.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ else
 	NPM = ./docker/bin/npm
 endif
 
+ifdef DATABASE
+	DOCKER_COMPOSE_PROFILE = --profile $(DATABASE)
+else
+	DOCKER_COMPOSE_PROFILE = --profile pgsql
+endif
+
 ifndef COVERAGE
 	COVERAGE = --coverage-html ./coverage
 endif
@@ -39,7 +45,7 @@ endif
 .PHONY: docker-start
 docker-start: ## Start a development server with Docker
 	@echo "Running webserver on http://localhost:8000"
-	$(DOCKER_COMPOSE) up
+	$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_PROFILE) up
 
 .PHONY: docker-build
 docker-build: ## Rebuild Docker containers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,8 +12,6 @@ services:
         volumes:
             - ..:/var/www/html:z
         user: $USER
-        links:
-            - database
 
     worker:
         image: bileto:dev
@@ -23,8 +21,6 @@ services:
         volumes:
             - ..:/var/www/html:z
         user: $USER
-        links:
-            - database
 
     bundler:
         image: node:18-alpine
@@ -43,21 +39,23 @@ services:
         volumes:
             - ..:/var/www/html:z
             - ./nginx.conf:/etc/nginx/conf.d/default.conf:z
-        links:
-            - php
 
-    database:
+    pgsql:
         image: postgres:11-alpine
         restart: unless-stopped
         environment:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: postgres
+        profiles:
+            - pgsql
 
-    # database:
-    #     image: mariadb:10.4
-    #     restart: unless-stopped
-    #     environment:
-    #       - MARIADB_ROOT_PASSWORD=mariadb
+    mariadb:
+        image: mariadb:10.4
+        restart: unless-stopped
+        environment:
+            MARIADB_ROOT_PASSWORD: mariadb
+        profiles:
+            - mariadb
 
     mailserver:
         image: greenmail/standalone:2.0.0

--- a/docs/developers/entity.md
+++ b/docs/developers/entity.md
@@ -136,7 +136,12 @@ if ($dbPlatform instanceof PostgreSQLPlatform) {
 
 Then, generate the migration for the other database.
 You can do that by changing the `DATABASE_URL` environment variable of the [`.env`](/.env) file (see the commented variable).
-You must also reverse the commented database service in the [`docker-compose.yml`](/docker/docker-compose.yml) file and restart the Docker containers.
+You must also restart the Docker containers by enabling MariaDB:
+
+```console
+$ make docker-start DATABASE=mariadb
+```
+
 Don’t forget to re-setup the database:
 
 ```console
@@ -149,10 +154,14 @@ You can now delete the last generated migration file, and reverse your changes:
 
 ```console
 $ rm migrations/VersionXXXX.php
-$ git checkout -- .env docker/docker-compose.yml
+$ git checkout -- .env
 ```
 
-Restart the docker containers, and re-setup the database as previously.
+Restart the docker containers:
+
+```console
+$ make docker-start
+```
 
 **Note:** it is indeed quite inconvenient.
 You’re very welcome to suggest a better system to handle migrations for several databases!

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -44,6 +44,18 @@ They are just shortcuts for common commands.
 If you want to know what they do, you can open the [Makefile](/Makefile) and locates the command that you are interested in.
 They are hopefully easily readable by newcomers.
 
+## Use MariaDB
+
+By default, `make docker-start` starts a PostgreSQL database.
+If you want to use MariaDB, just pass the `DATABASE` variable to the command:
+
+```console
+$ make docker-start DATABASE=mariadb
+```
+
+You’ll also need to change the `DATABASE_URL` value in the [`.env` file](/.env) (just uncomment the second line).
+If you want to make this change permanent, create a `.env.local` file and copy the line into it.
+
 ## Working in the Docker containers
 
 There are few scripts to allow to execute commands in the Docker containers easily:


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- uncomment the MariaDB service in the docker-compose.yml file
- rename the Docker database services
- assign profiles to the database services
- enable the given profile on `make docker-start`
- adapt the `DATABASE_URL` lines in the `.env` file

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make docker-start` → check it starts the pgsql service (and not the mariadb service)
- run `make docker-start DATABASE=mariadb` → check it starts the mariadb service (and not the pgsql service)

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
