### PR TITLE
fix: Allow no name to be entered in the profile

### DIFF
--- a/templates/profile/edit.html.twig
+++ b/templates/profile/edit.html.twig
@@ -49,7 +49,6 @@
                     id="name"
                     name="name"
                     value="{{ name }}"
-                    required
                     maxlength="100"
                     autocomplete="name"
                     {% if errors.name is defined %}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/174

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- remove the `required` attribute from the name field of the profile form

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- go to the profile
- submit an empty name → check it works

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
