### PR TITLE
imp: Schedule the synchronization of LDAP

### DIFF
--- a/.env
+++ b/.env
@@ -41,23 +41,29 @@ LDAP_VERSION=3
 LDAP_ENCRYPTION="none"
 
 # The base DN of the LDAP directory.
-LDAP_BASE_DN="dc=example,dc=com"
+LDAP_BASE_DN="ou=users,dc=example,dc=com"
 
 # The credentials of the admin user of the LDAP directory.
 LDAP_ADMIN_DN="cn=admin,dc=example,dc=com"
 LDAP_ADMIN_PASSWORD="secret"
 
 # The DN to log a user in the LDAP directory. The {user_identifier} placeholder
-# will be replaced by the value entered by the users.
+# is replaced by the value entered by the users.
 LDAP_USERS_DN="cn={user_identifier},ou=users,dc=example,dc=com"
 
-# The search query to find users in the LDAP directory when they aren't know by
-# Bileto. The {user_identifier} placeholder will be replaced by the value
-# entered by the users. If you use a different attribute than in LDAP_USERS_DN,
-# make sure that the values are identical in the LDAP directory.
-LDAP_SEARCH_QUERY="(uid={user_identifier})"
+# The search query to list all the users from the LDAP directory. This is used
+# to synchronize automatically the list of users.
+LDAP_QUERY_LIST_USERS="(cn=*)"
 
-# The name of the LDAP attributes to search for the email and the fullname of
-# the users.
+# The search query to find a user in the LDAP directory when they aren't known
+# by Bileto. The {user_identifier} placeholder is replaced by the value entered
+# by the user. If you use a different attribute than in LDAP_USERS_DN and
+# LDAP_FIELD_IDENTIFIER, make sure that the values are identical in the LDAP
+# directory.
+LDAP_QUERY_SEARCH_USER="(cn={user_identifier})"
+
+# The name of the LDAP attributes to search for the identifier, the email and
+# the fullname of the users.
+LDAP_FIELD_IDENTIFIER=cn
 LDAP_FIELD_EMAIL=mail
 LDAP_FIELD_FULLNAME=displayName

--- a/docs/administrators/deploy.md
+++ b/docs/administrators/deploy.md
@@ -286,3 +286,10 @@ If you don’t find them, copy paste them from the [`env.sample` file](/env.samp
 The comments above the variables should be clear enough to help you.
 
 To test your setup, try to login with a user and monitor the application logs for any related errors.
+
+The LDAP directory is synchronized every 12 hours, but new users can log into Bileto immediately.
+If you need to synchronize manually, you can run:
+
+```console
+www-data$ php bin/console app:ldap:sync
+```

--- a/env.sample
+++ b/env.sample
@@ -41,23 +41,29 @@ LDAP_ENABLED=false
 # LDAP_ENCRYPTION="ssl"
 
 # The base DN of the LDAP directory.
-# LDAP_BASE_DN="dc=example,dc=com"
+# LDAP_BASE_DN="ou=users,dc=example,dc=com"
 
 # The credentials of the admin user of the LDAP directory.
 # LDAP_ADMIN_DN="cn=admin,dc=example,dc=com"
 # LDAP_ADMIN_PASSWORD="secret"
 
 # The DN to log a user in the LDAP directory. The {user_identifier} placeholder
-# will be replaced by the value entered by the users.
+# is replaced by the value entered by the users.
 # LDAP_USERS_DN="cn={user_identifier},ou=users,dc=example,dc=com"
 
-# The search query to find users in the LDAP directory when they aren't know by
-# Bileto. The {user_identifier} placeholder will be replaced by the value
-# entered by the users. If you use a different attribute than in LDAP_USERS_DN,
-# make sure that the values are identical in the LDAP directory.
-# LDAP_SEARCH_QUERY="(uid={user_identifier})"
+# The search query to list all the users from the LDAP directory. This is used
+# to synchronize automatically the list of users.
+# LDAP_QUERY_LIST_USERS="(cn=*)"
 
-# The name of the LDAP attributes to search for the email and the fullname of
-# the users.
+# The search query to find a user in the LDAP directory when they aren't known
+# by Bileto. The {user_identifier} placeholder is replaced by the value entered
+# by the user. If you use a different attribute than in LDAP_USERS_DN and
+# LDAP_FIELD_IDENTIFIER, make sure that the values are identical in the LDAP
+# directory.
+# LDAP_QUERY_SEARCH_USER="(cn={user_identifier})"
+
+# The name of the LDAP attributes to search for the identifier, the email and
+# the fullname of the users.
+# LDAP_FIELD_IDENTIFIER=cn
 # LDAP_FIELD_EMAIL=mail
 # LDAP_FIELD_FULLNAME=displayName

--- a/src/Command/Ldap/SyncCommand.php
+++ b/src/Command/Ldap/SyncCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Command\Ldap;
+
+use App\Message\SynchronizeLdap;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+
+#[AsCommand(
+    name: 'app:ldap:sync',
+    description: 'Synchronize the LDAP directory manually',
+)]
+class SyncCommand extends Command
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->bus->dispatch(new SynchronizeLdap(), [
+            new TransportNamesStamp('sync'),
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Message/SynchronizeLdap.php
+++ b/src/Message/SynchronizeLdap.php
@@ -1,0 +1,11 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Message;
+
+class SynchronizeLdap
+{
+}

--- a/src/MessageHandler/SynchronizeLdapHandler.php
+++ b/src/MessageHandler/SynchronizeLdapHandler.php
@@ -1,0 +1,87 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\MessageHandler;
+
+use App\Entity\User;
+use App\Message\SynchronizeLdap;
+use App\Repository\UserRepository;
+use App\Service\Ldap;
+use App\Utils\ConstraintErrorsFormatter;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsMessageHandler]
+class SynchronizeLdapHandler
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private Ldap $ldap,
+        private LoggerInterface $logger,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    public function __invoke(SynchronizeLdap $message): void
+    {
+        $ldapUsers = $this->ldap->listUsers();
+        $userRepository = $this->entityManager->getRepository(User::class);
+
+        $countUsers = count($ldapUsers);
+
+        if ($countUsers === 0) {
+            return;
+        }
+
+        $this->logger->notice("[SynchronizeLdap] {$countUsers} users to synchronize");
+
+        $countCreated = 0;
+        $countUpdated = 0;
+        $countErrors = 0;
+
+        foreach ($ldapUsers as $ldapUser) {
+            $user = $userRepository->findOneBy(['email' => $ldapUser->getEmail()]);
+
+            if ($user) {
+                $user->setLdapIdentifier($ldapUser->getLdapIdentifier());
+                $user->setEmail($ldapUser->getEmail());
+                $user->setName($ldapUser->getName());
+
+                $countUpdated += 1;
+            } else {
+                $user = $ldapUser;
+
+                $countCreated += 1;
+            }
+
+            $errors = $this->validator->validate($user);
+
+            if (count($errors) > 0) {
+                $errors = implode(' ', ConstraintErrorsFormatter::format($errors));
+                $this->logger->error(
+                    "[SynchronizeLdap] Can't sync user {$user->getLdapIdentifier()}: {$errors}"
+                );
+
+                $countErrors += 1;
+
+                continue;
+            }
+
+            $this->entityManager->persist($user);
+        }
+
+        $this->entityManager->flush();
+
+        $this->logger->notice(
+            "[SynchronizeLdap] " .
+            "{$countCreated} user(s) created ; " .
+            "{$countUpdated} user(s) updated ; " .
+            "{$countErrors} error(s)"
+        );
+    }
+}

--- a/src/Scheduler/DefaultScheduleProvider.php
+++ b/src/Scheduler/DefaultScheduleProvider.php
@@ -6,8 +6,9 @@
 
 namespace App\Scheduler;
 
-use App\Message\FetchMailboxes;
 use App\Message\CreateTicketsFromMailboxEmails;
+use App\Message\FetchMailboxes;
+use App\Message\SynchronizeLdap;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
@@ -22,6 +23,8 @@ class DefaultScheduleProvider implements ScheduleProviderInterface
 
         $schedule->add(RecurringMessage::every('1 minute', new FetchMailboxes()));
         $schedule->add(RecurringMessage::every('1 minute', new CreateTicketsFromMailboxEmails()));
+
+        $schedule->add(RecurringMessage::every('12 hours', new SynchronizeLdap()));
 
         return $schedule;
     }

--- a/tests/MessageHandler/SynchronizeLdapHandlerTest.php
+++ b/tests/MessageHandler/SynchronizeLdapHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\SynchronizeLdap;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SynchronizeLdapHandlerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testInvokeCreatesUsers(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $this->assertSame(0, UserFactory::count());
+
+        $bus->dispatch(new SynchronizeLdap());
+
+        $this->assertSame(2, UserFactory::count());
+
+        $users = UserFactory::all();
+        $this->assertSame('charlie', $users[0]->getLdapIdentifier());
+        $this->assertSame('charlie@example.com', $users[0]->getEmail());
+        $this->assertSame('Charlie Gature', $users[0]->getName());
+        $this->assertSame('dominique', $users[1]->getLdapIdentifier());
+        $this->assertSame('dominique@example.com', $users[1]->getEmail());
+        $this->assertSame('Dominique Aragua', $users[1]->getName());
+    }
+
+    public function testInvokeUpdateUsers(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+        $user = UserFactory::createOne([
+            'email' => 'charlie@example.com',
+            'name' => 'C. Gature',
+            'ldapIdentifier' => 'cgature',
+        ]);
+
+        $bus->dispatch(new SynchronizeLdap());
+
+        $user->refresh();
+        $this->assertSame('charlie', $user->getLdapIdentifier());
+        $this->assertSame('charlie@example.com', $user->getEmail());
+        $this->assertSame('Charlie Gature', $user->getName());
+    }
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/168

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- change the default value of env variable `LDAP_BASE_DN`
- rename env variable `LDAP_SEARCH_QUERY` in `LDAP_QUERY_SEARCH_USER`
- add env variables `LDAP_QUERY_LIST_USERS` and `LDAP_FIELD_IDENTIFIER`
- add a method to the Ldap service to list the users from the directory
- add a message + its handler to synchronize the users from LDAP
- schedule the message every 12h
- provide a console command to synchronize manually

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- reset the database `make db-reset FORCE=true`
- run `./docker/bin/console app:ldap:sync`
- check in db (`./docker/bin/psql bileto`, `SELECT * FROM users`) that the user `dominique@example.com` exists
- run `./docker/bin/console debug:scheduler`
- check that the `SynchronizeLdap` message is scheduled every 12 hours

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
