### PR TITLE
imp: Allow admin to change the LDAP identifiers

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -256,7 +256,7 @@ class User implements
         return $this->ldapIdentifier;
     }
 
-    public function setLdapIdentifier(string $ldapIdentifier): static
+    public function setLdapIdentifier(?string $ldapIdentifier): static
     {
         $this->ldapIdentifier = $ldapIdentifier;
 

--- a/src/MessageHandler/SynchronizeLdapHandler.php
+++ b/src/MessageHandler/SynchronizeLdapHandler.php
@@ -45,10 +45,11 @@ class SynchronizeLdapHandler
         $countErrors = 0;
 
         foreach ($ldapUsers as $ldapUser) {
-            $user = $userRepository->findOneBy(['email' => $ldapUser->getEmail()]);
+            $user = $userRepository->findOneBy([
+                'ldapIdentifier' => $ldapUser->getLdapIdentifier(),
+            ]);
 
             if ($user) {
-                $user->setLdapIdentifier($ldapUser->getLdapIdentifier());
                 $user->setEmail($ldapUser->getEmail());
                 $user->setName($ldapUser->getName());
 

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -28,6 +28,14 @@
                 {{ include('alerts/_error.html.twig', { message: error }, with_context = false) }}
             {% endif %}
 
+            {% if managedByLdap %}
+                {{ include('alerts/_alert.html.twig', {
+                    type: 'info',
+                    title: 'users.edit.ldap.information' | trans,
+                    message: 'users.edit.ldap.managed' | trans,
+                }, with_context = false) }}
+            {% endif %}
+
             <div class="flow flow--small">
                 <label for="email">
                     {{ 'users.email' | trans }}
@@ -51,15 +59,19 @@
                         aria-invalid="true"
                         aria-errormessage="email-error"
                     {% endif %}
+                    {{ managedByLdap ? 'disabled' }}
                 />
             </div>
 
             <div class="flow flow--small">
                 <label for="name">
                     {{ 'users.name' | trans }}
-                    <span class="text--secondary">
-                        {{ 'forms.optional_max_chars' | trans({ number: 100 }) }}
-                    </span>
+
+                    {% if not managedByLdap %}
+                        <span class="text--secondary">
+                            {{ 'forms.optional_max_chars' | trans({ number: 100 }) }}
+                        </span>
+                    {% endif %}
                 </label>
 
                 {% if errors.name is defined %}
@@ -80,45 +92,76 @@
                         aria-invalid="true"
                         aria-errormessage="name-error"
                     {% endif %}
+                    {{ managedByLdap ? 'disabled' }}
                 />
             </div>
 
-            <div class="flow flow--small">
-                <label for="password">
-                    {{ 'users.password' | trans }}
+            {% if ldapEnabled %}
+                <label for="ldap-identifier">
+                    {{ 'users.ldap_identifier' | trans }}
+
                     <span class="text--secondary">
                         {{ 'forms.optional' | trans }}
                     </span>
                 </label>
 
-                <p class="form__caption" id="password-caption">
-                    {{ 'users.edit.leave_password_empty' | trans }}
-                </p>
+                {% if errors.ldapIdentifier is defined %}
+                    <p class="form__error" role="alert" id="ldap-identifier-error">
+                        <span class="sr-only">{{ 'forms.error' | trans }}</span>
+                        {{ errors.ldapIdentifier }}
+                    </p>
+                {% endif %}
 
-                <div class="input-container" data-controller="password">
-                    <input
-                        type="password"
-                        id="password"
-                        name="password"
-                        autocomplete="new-password"
-                        data-password-target="input"
-                        aria-describedby="password-caption"
-                    />
+                <input
+                    type="text"
+                    id="ldap-identifier"
+                    name="ldapIdentifier"
+                    value="{{ ldapIdentifier }}"
+                    {% if errors.ldapIdentifier is defined %}
+                        aria-invalid="true"
+                        aria-errormessage="ldap-identifier-error"
+                    {% endif %}
+                />
+            {% endif %}
 
-                    <button
-                        type="button"
-                        role="switch"
-                        data-action="password#toggle"
-                        data-password-target="button"
-                    >
-                        {{ icon('eye') }}
-                        {{ icon('eye-slash') }}
-                        <span class="sr-only">
-                            {{ 'forms.show_password' | trans }}
+            {% if not managedByLdap %}
+                <div class="flow flow--small">
+                    <label for="password">
+                        {{ 'users.password' | trans }}
+                        <span class="text--secondary">
+                            {{ 'forms.optional' | trans }}
                         </span>
-                    </button>
+                    </label>
+
+                    <p class="form__caption" id="password-caption">
+                        {{ 'users.edit.leave_password_empty' | trans }}
+                    </p>
+
+                    <div class="input-container" data-controller="password">
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            autocomplete="new-password"
+                            data-password-target="input"
+                            aria-describedby="password-caption"
+                        />
+
+                        <button
+                            type="button"
+                            role="switch"
+                            data-action="password#toggle"
+                            data-password-target="button"
+                        >
+                            {{ icon('eye') }}
+                            {{ icon('eye-slash') }}
+                            <span class="sr-only">
+                                {{ 'forms.show_password' | trans }}
+                            </span>
+                        </button>
+                    </div>
                 </div>
-            </div>
+            {% endif %}
 
             <div class="flow flow--small">
                 <label for="organization">

--- a/tests/MessageHandler/SynchronizeLdapHandlerTest.php
+++ b/tests/MessageHandler/SynchronizeLdapHandlerTest.php
@@ -45,16 +45,16 @@ class SynchronizeLdapHandlerTest extends WebTestCase
         /** @var MessageBusInterface */
         $bus = $container->get(MessageBusInterface::class);
         $user = UserFactory::createOne([
-            'email' => 'charlie@example.com',
+            'email' => 'cgature@example.com',
             'name' => 'C. Gature',
-            'ldapIdentifier' => 'cgature',
+            'ldapIdentifier' => 'charlie',
         ]);
 
         $bus->dispatch(new SynchronizeLdap());
 
         $user->refresh();
-        $this->assertSame('charlie', $user->getLdapIdentifier());
         $this->assertSame('charlie@example.com', $user->getEmail());
         $this->assertSame('Charlie Gature', $user->getName());
+        $this->assertSame('charlie', $user->getLdapIdentifier());
     }
 }

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -321,6 +321,8 @@ users.color_scheme: 'Color scheme'
 users.color_scheme.auto: Auto
 users.color_scheme.dark: Dark
 users.color_scheme.light: Light
+users.edit.ldap.information: Information
+users.edit.ldap.managed: 'You can’t change some information because this account is managed by LDAP.'
 users.edit.leave_password_empty: 'Leave blank to keep the current password.'
 users.edit.organization_caption: 'The tickets opened by email by this user will be attached to this organization.'
 users.edit.title: 'Edit a user'
@@ -332,6 +334,7 @@ users.index.new_user: 'New user'
 users.index.number: '{count, plural, =0 {No users} one {1 user} other {# users}}'
 users.index.title: Users
 users.language: Language
+users.ldap_identifier: 'LDAP identifier'
 users.n_others: '{number, plural, =0 {no other} one {1 other} other {# other}}'
 users.name: Name
 users.new.leave_password_empty: '(leave empty to forbid login)'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -321,6 +321,8 @@ users.color_scheme: 'Schéma de couleurs'
 users.color_scheme.auto: Auto
 users.color_scheme.dark: Sombre
 users.color_scheme.light: Clair
+users.edit.ldap.information: Information
+users.edit.ldap.managed: 'Certaines informations ne sont pas modifiables car ce compte est géré avec LDAP.'
 users.edit.leave_password_empty: 'Laissez vide pour conserver le mot de passe actuel.'
 users.edit.organization_caption: 'Les tickets ouverts par email par cet utilisateur seront attachés à cette organisation.'
 users.edit.title: 'Modifier un utilisateur'
@@ -332,6 +334,7 @@ users.index.new_user: 'Nouvel utilisateur'
 users.index.number: '{count, plural, =0 {Aucun utilisateur} one {1 utilisateur} other {# utilisateurs}}'
 users.index.title: Utilisateurs
 users.language: Langue
+users.ldap_identifier: 'Identifiant LDAP'
 users.n_others: '{number, plural, =0 {aucun autre} one {1 autre} other {# autres}}'
 users.name: Nom
 users.new.leave_password_empty: '(laissez vide pour empêcher la connexion)'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/168

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- in admin, forbid changing name, email and password of users if ldapIdentifier is set
- add an input to change the ldapIdentifier
- when synchronizing, search users by their ldapIdentifier instead of email

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- go to the settings > users
- edit charlie user → check that you can't change email, name or password
- empty the ldapIdentifier input → check that you can now change email, name and password
- set "charlie" back to the ldapIdentifier and run `./docker/bin/console app:ldap:sync`
- check that the information are back

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
