### PR TITLE
imp: Redirect if user can create ticket in its default organization

### DIFF
--- a/tests/Controller/TicketsControllerTest.php
+++ b/tests/Controller/TicketsControllerTest.php
@@ -57,6 +57,21 @@ class TicketsControllerTest extends WebTestCase
         $this->assertSelectorTextContains('h1', 'New ticket');
     }
 
+    public function testGetNewRedirectsIfUserCanCreateTicketInItsDefaultOrganization(): void
+    {
+        $client = static::createClient();
+        list($orga1, $orga2) = OrganizationFactory::createMany(2);
+        $user = UserFactory::createOne([
+            'organization' => $orga1,
+        ]);
+        $client->loginUser($user->object());
+        $this->grantOrga($user->object(), ['orga:create:tickets']);
+
+        $client->request('GET', '/tickets/new');
+
+        $this->assertResponseRedirects("/organizations/{$orga1->getUid()}/tickets/new", 302);
+    }
+
     public function testGetNewRedirectsIfOnlyOneOrganizationIsAccessible(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/387

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- when creating a ticket, redirect to the orga "new ticket" if the user can create tickets in its default organization

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- with Alix user, click on the "New ticket" link on the homepage
- check that you're redirected to the the "Probesys" new ticket form

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
