### PR TITLE
misc: Handle unknown mimetype in MessageDocumentFactory

### DIFF
--- a/tests/Factory/MessageDocumentFactory.php
+++ b/tests/Factory/MessageDocumentFactory.php
@@ -61,7 +61,7 @@ final class MessageDocumentFactory extends ModelFactory
         $mimetype = self::faker()->randomElement(array_keys(MessageDocument::ACCEPTED_MIMETYPES));
         $mimesubtype = self::faker()->randomElement(MessageDocument::ACCEPTED_MIMETYPES[$mimetype]);
         $mimetype = "{$mimetype}/{$mimesubtype}";
-        $extension = MimeTypes::getDefault()->getExtensions($mimetype)[0];
+        $extension = MimeTypes::getDefault()->getExtensions($mimetype)[0] ?? 'txt';
         return [
             'uid' => Random::hex(20),
             'name' => self::faker()->words(3, true),


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- default to "txt" extension when `MimeTypes` returns no extension in the `MessageDocumentFactory`

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- N/A

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
