### PR TITLE
imp: Allow to detach documents when posting a message

### DIFF
--- a/assets/javascripts/controllers/form_message_documents_controller.js
+++ b/assets/javascripts/controllers/form_message_documents_controller.js
@@ -19,6 +19,8 @@ export default class extends Controller {
         nameNode.innerHTML = doc.name;
         const linkNode = docNode.querySelector('[data-target="document-link"]');
         linkNode.href = doc.urlShow;
+        const deleteFormNode = docNode.querySelector('[data-target="document-delete-form"]');
+        deleteFormNode.action = doc.urlDelete;
 
         this.documentsTarget.appendChild(docNode);
 
@@ -27,5 +29,40 @@ export default class extends Controller {
         hiddenInputNode.name = 'messageDocumentUids[]';
         hiddenInputNode.value = doc.uid;
         this.element.appendChild(hiddenInputNode);
+    }
+
+    removeDocument (event) {
+        // Catch the submit event and send it asynchronously to the server.
+        event.preventDefault();
+
+        const form = event.target;
+        const docNode = form.closest('[data-target="document"]');
+        const linkNode = docNode.querySelector('[data-target="document-link"]');
+        const urlShow = linkNode.href;
+
+        const data = new FormData(form);
+        fetch(form.action, {
+            method: 'POST',
+            body: data,
+        }).then((response) => {
+            // Remove the document node from the list.
+            docNode.remove();
+
+            return response.json();
+        }).then((json) => {
+            // Remove the document from the hidden inputs of the form
+            const inputSelector = 'input[name="messageDocumentUids[]"][value="' + json.uid + '"]';
+            const input = this.element.querySelector(inputSelector);
+            if (input) {
+                input.remove();
+            }
+
+            // Remove the image if it was present in an active TinyMCE editor.
+            if (window.tinymce && window.tinymce.activeEditor) {
+                const selector = 'img[src="' + urlShow + '"]';
+                const images = window.tinymce.activeEditor.dom.select(selector);
+                window.tinymce.activeEditor.dom.remove(images);
+            }
+        });
     }
 }

--- a/assets/stylesheets/components/documents.css
+++ b/assets/stylesheets/components/documents.css
@@ -11,7 +11,7 @@
 
 .documents__link {
     display: block;
-    padding: 2rem;
+    padding: 2rem 1rem;
     /* Padding around the icon + icon size (see background properties) */
     padding-left: calc(1rem + 2rem + 1rem);
 
@@ -45,4 +45,8 @@
 
 .documents__item[data-type="file"] .documents__link {
     background-image: url('../../icons/file.svg');
+}
+
+.documents__delete {
+    padding: 2rem 1rem;
 }

--- a/src/Controller/MessageDocumentsController.php
+++ b/src/Controller/MessageDocumentsController.php
@@ -77,12 +77,19 @@ class MessageDocumentsController extends BaseController
             ],
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
+        $urlDelete = $this->generateUrl(
+            'delete message document',
+            [
+                'uid' => $messageDocument->getUid(),
+            ],
+        );
 
         return new JsonResponse([
             'uid' => $messageDocument->getUid(),
             'name' => $messageDocument->getName(),
             'type' => $messageDocument->getType(),
             'urlShow' => $urlShow,
+            'urlDelete' => $urlDelete,
         ]);
     }
 

--- a/src/Repository/MessageDocumentRepository.php
+++ b/src/Repository/MessageDocumentRepository.php
@@ -44,4 +44,18 @@ class MessageDocumentRepository extends ServiceEntityRepository implements UidGe
             $this->getEntityManager()->flush();
         }
     }
+
+    public function countByHash(string $hash): int
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT COUNT(md)
+            FROM App\Entity\MessageDocument md
+            WHERE md.hash = :hash
+        SQL);
+        $query->setParameter('hash', $hash);
+
+        return $query->getSingleScalarResult();
+    }
 }

--- a/src/Service/MessageDocumentStorage.php
+++ b/src/Service/MessageDocumentStorage.php
@@ -76,6 +76,15 @@ class MessageDocumentStorage
     }
 
     /**
+     * Return whether the file exists or not.
+     */
+    public function exists(MessageDocument $messageDocument): bool
+    {
+        $pathname = "{$this->uploadsDirectory}/{$messageDocument->getPathname()}";
+        return @file_exists($pathname);
+    }
+
+    /**
      * Return the size of the file related to the given MessageDocument.
      *
      * @throws MessageDocumentStorageError
@@ -109,5 +118,14 @@ class MessageDocumentStorage
         }
 
         return $content;
+    }
+
+    /**
+     * Remove the file related to the given MessageDocument.
+     */
+    public function remove(MessageDocument $messageDocument): bool
+    {
+        $pathname = "{$this->uploadsDirectory}/{$messageDocument->getPathname()}";
+        return @unlink($pathname);
     }
 }

--- a/templates/message_documents/_list.html.twig
+++ b/templates/message_documents/_list.html.twig
@@ -9,9 +9,9 @@
     </ul>
 
     <template data-form-message-documents-target="documentTemplate">
-        <li class="documents__item" data-target="document">
+        <li class="documents__item row row--always row--center" data-target="document">
             <a
-                class="documents__link"
+                class="documents__link row__item--extend"
                 target="_blank"
                 data-target="document-link"
             >
@@ -20,6 +20,23 @@
                     data-target="document-name"
                 ></span>
             </a>
+
+            <form
+                class="documents__delete"
+                method="post"
+                action=""
+                data-target="document-delete-form"
+                data-action="form-message-documents#removeDocument"
+            >
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token('delete message document') }}">
+                <button class="button--icon" type="submit">
+                    {{ icon('close') }}
+
+                    <span class="sr-only">
+                        {{ 'message_documents.remove' | trans }}
+                    </span>
+                </button>
+            </form>
         </li>
     </template>
 </div>

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -105,6 +105,7 @@ mailboxes.password: Password
 mailboxes.port: 'Port IMAP'
 mailboxes.test.success: 'The connection works.'
 mailboxes.username: Username
+message_documents.remove: 'Remove attachment'
 notifications.saved: 'Your changes have been successfully saved.'
 organizations.deletion.caution: Caution!
 organizations.deletion.confirm: 'Are you sure that you want to delete this organization?'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -105,6 +105,7 @@ mailboxes.password: 'Mot de passe'
 mailboxes.port: 'Port IMAP'
 mailboxes.test.success: 'La connexion fonctionne.'
 mailboxes.username: 'Nom d’utilisateur'
+message_documents.remove: 'Retirer la pièce-jointe'
 notifications.saved: 'Vos changements ont été sauvegardés.'
 organizations.deletion.caution: "Attention\_!"
 organizations.deletion.confirm: "Êtes-vous sûr de vouloir supprimer cette organisation\_?"


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/149

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- add an endpoint to delete a MessageDocument
- return the url to delete a MessageDocument when uploading a file
- when uploading a file, add a "delete" button to detach it
- add a handler to remove a document asynchronously, remove it from the TinyMCE editor and from the hidden inputs

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- start a new message
- upload an image
- detach the file → check it disappears from the editor
- post the message → check there is no attachments

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [ ] code is manually tested
- [ ] permissions / authorizations are verified
- [ ] interface works on both mobiles and big screens
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up-to-date
- [ ] documentation is up-to-date (including migration notes)
