### PR TITLE
imp: Import emails attachments as MessageDocuments

### DIFF
--- a/docs/developers/email-collector.md
+++ b/docs/developers/email-collector.md
@@ -29,7 +29,8 @@ For each `MailboxEmail`:
 3. it detects a potential ticket to which the email might reply;
 4. if it detects a ticket, it checks that the requester can answer to it and that it is not closed;
 5. otherwise it checks the requester has the permission to create tickets in the organization and it creates one based on the `Subject` and the `Body` of the email;
-6. finally, it deletes the `MailboxEmail` from the database.
+6. it saves attachments as `MessageDocument`s;
+7. finally, it deletes the `MailboxEmail` from the database.
 
 If anything goes wrong during this process, the error is logged in the relevant `MailboxEmail` `lastError` field.
 

--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -176,6 +176,15 @@ class MailboxEmail implements MetaEntityInterface, ActivityRecordableInterface
         }
     }
 
+    /**
+     * @return PHPIMAP\Attachment[]
+     */
+    public function getAttachments(): array
+    {
+        $email = $this->getEmail();
+        return $email->getAttachments()->toArray();
+    }
+
     public function getDate(): \DateTimeImmutable
     {
         $date = $this->getEmail()->getDate()->first();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/149

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- Add a method to get PHPIMAP attachments from a `MailboxEmail`
- Save attachments as files and store them with `MessageDocumentStorage` in `CreateTicketsFromMailboxEmailsHandler.php`

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- send an email to `support@example.com` with attachments
- check a ticket is created and that attachments are set in the message

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
