### PR TITLE
fix: Fix size of images in messages

### DIFF
--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -16,6 +16,9 @@ framework:
 
                 block_elements: ['html', 'body']
 
+                allow_attributes:
+                    width: ['img']
+
                 force_attributes:
                     a:
                         rel: noopener noreferrer


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/149

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- allow `width` on `img`

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- insert an image in a message
- resize it
- check the size is respected in the final message

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
