### PR TITLE
fix: Adapt the editor background to color scheme

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 - [ ] code is manually tested
 - [ ] permissions / authorizations are verified
 - [ ] interface works on both mobiles and big screens
+- [ ] interface works in both light and dark modes
 - [ ] accessibility has been tested
 - [ ] tests are up-to-date
 - [ ] locales are synchronized

--- a/assets/stylesheets/components/forms.css
+++ b/assets/stylesheets/components/forms.css
@@ -250,11 +250,19 @@ legend {
 }
 
 .editor {
-    background-color: #fff;
+    background-color: var(--tinymce-background);
     border: 0.25rem solid var(--color-grey8);
     border-radius: 0.5rem;
 
     transition: border-color 0.2s ease-in-out;
+}
+
+[data-color-scheme="light"] .editor {
+    --tinymce-background: #fff;
+}
+
+[data-color-scheme="dark"] .editor {
+    --tinymce-background: #222f3e;
 }
 
 .editor:hover,
@@ -268,6 +276,7 @@ legend {
 
 .editor .tox-tinymce {
     border: none;
+    border-radius: 0.5rem 0.5rem 0 0;
 }
 
 .form__caption {


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/437

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- adapt the color of the editor background to match with the background of TinyMCE, depending on the color scheme
- add an item to the PR checklist to check that interface works in both light and dark modes

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- switch to dark mode
- check that the editor looks fine

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
