### PR TITLE
fix: Fix the year format in the Twig dateTrans filter

### DIFF
--- a/src/Twig/DateFormatterExtension.php
+++ b/src/Twig/DateFormatterExtension.php
@@ -30,7 +30,7 @@ class DateFormatterExtension extends AbstractExtension
         ];
     }
 
-    public function dateTrans(\DateTimeInterface $date, string $format = 'dd MMM Y, HH:mm'): string
+    public function dateTrans(\DateTimeInterface $date, string $format = 'dd MMM yyyy, HH:mm'): string
     {
         return $this->dateTranslator->format($date, $format);
     }
@@ -55,7 +55,7 @@ class DateFormatterExtension extends AbstractExtension
         }
 
         if (!$cleverYear || $currentYear !== $dateYear) {
-            $format .= ' Y';
+            $format .= ' yyyy';
         }
 
         $format .= ', HH:mm';
@@ -78,7 +78,7 @@ class DateFormatterExtension extends AbstractExtension
         }
 
         if (!$cleverYear || $currentYear !== $dateYear) {
-            $format .= ' Y';
+            $format .= ' yyyy';
         }
 
         return $this->dateTrans($date, $format);

--- a/templates/organizations/contracts/new.html.twig
+++ b/templates/organizations/contracts/new.html.twig
@@ -111,7 +111,7 @@
                         type="date"
                         id="start-at"
                         name="startAt"
-                        value="{{ startAt ? startAt | dateTrans('Y-MM-dd') }}"
+                        value="{{ startAt ? startAt | dateTrans('yyyy-MM-dd') }}"
                         required
                         data-form-new-contract-target="startAt"
                         data-action="form-new-contract#updateEndAt"
@@ -138,7 +138,7 @@
                         type="date"
                         id="end-at"
                         name="endAt"
-                        value="{{ endAt ? endAt | dateTrans('Y-MM-dd') }}"
+                        value="{{ endAt ? endAt | dateTrans('yyyy-MM-dd') }}"
                         required
                         data-form-new-contract-target="endAt"
                         {% if errors.endAt is defined %}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- use `yyyy` pattern instead of `Y` when formatting the years

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- set the date of your computer to "2023-01-01"
- start a new contract → check that the startAt input is set to "2023-01-01"

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
