### PR TITLE
imp: Move the new contract's max hours input

### DIFF
--- a/templates/organizations/contracts/new.html.twig
+++ b/templates/organizations/contracts/new.html.twig
@@ -64,38 +64,6 @@
 
             <div class="row flow">
                 <div class="row__item--extend flow flow--small">
-                    <label for="max-hours">
-                        {{ 'contracts.max_hours' | trans }}
-                    </label>
-
-                    {% if errors.maxHours is defined %}
-                        <p class="form__error" role="alert" id="max-hours-error">
-                            <span class="sr-only">{{ 'forms.error' | trans }}</span>
-                            {{ errors.maxHours }}
-                        </p>
-                    {% endif %}
-
-                    <input
-                        type="number"
-                        id="max-hours"
-                        name="maxHours"
-                        value="{{ maxHours }}"
-                        min="0"
-                        step="1"
-                        required
-                        {% if errors.maxHours is defined %}
-                            aria-invalid="true"
-                            aria-errormessage="max-hours-error"
-                        {% endif %}
-                    />
-                </div>
-
-                <div class="row__item--extend">
-                </div>
-            </div>
-
-            <div class="row flow">
-                <div class="row__item--extend flow flow--small">
                     <label for="start-at">
                         {{ 'contracts.start_at' | trans }}
                     </label>
@@ -147,6 +115,34 @@
                         {% endif %}
                     />
                 </div>
+            </div>
+
+            <div class="flow flow--small">
+                <label for="max-hours">
+                    {{ 'contracts.max_hours' | trans }}
+                </label>
+
+                {% if errors.maxHours is defined %}
+                    <p class="form__error" role="alert" id="max-hours-error">
+                        <span class="sr-only">{{ 'forms.error' | trans }}</span>
+                        {{ errors.maxHours }}
+                    </p>
+                {% endif %}
+
+                <input
+                    type="number"
+                    id="max-hours"
+                    name="maxHours"
+                    value="{{ maxHours }}"
+                    min="0"
+                    step="1"
+                    required
+                    class="input--size3"
+                    {% if errors.maxHours is defined %}
+                        aria-invalid="true"
+                        aria-errormessage="max-hours-error"
+                    {% endif %}
+                />
             </div>
 
             <div class="flow flow--small">


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/29
https://github.com/Probesys/bileto/issues/35

## Changes

<!-- List the changes you’ve made in this pull request in order to help the
  -- reviewers to understand how to review it. -->

- move the max hours input below the dates
- set the size of the input with a dedicated class

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- go to the "new contract" form → check the max hours input is below the dates inputs

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [ ] code is manually tested
- [ ] permissions / authorizations are verified
- [ ] interface works on both mobiles and big screens
- [ ] interface works in both light and dark modes
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up-to-date
- [ ] documentation is up-to-date (including migration notes)
