### PR TITLE
fix: Hide renew contract button if permissions are not granted

### DIFF
--- a/templates/organizations/contracts/show.html.twig
+++ b/templates/organizations/contracts/show.html.twig
@@ -34,10 +34,12 @@
                     </span>
                 </div>
 
-                <a class="anchor--action" href="{{ path('new organization contract', { uid: organization.uid, from: contract.uid }) }}">
-                    {{ icon('repeat') }}
-                    {{ 'contracts.show.renew' | trans }}
-                </a>
+                {% if is_granted('orga:manage:contracts', organization) %}
+                    <a class="anchor--action" href="{{ path('new organization contract', { uid: organization.uid, from: contract.uid }) }}">
+                        {{ icon('repeat') }}
+                        {{ 'contracts.show.renew' | trans }}
+                    </a>
+                {% endif %}
             </div>
 
             {% if contract.billingInterval %}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/473

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- create a contract
- with a user which has the permission to see the contracts but not to manage them, go to the contract
- check the "renew" button is not appearing

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
