### PR TITLE
dev: Restore security files on make translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ endif
 translations: ## Update the translations from the code
 	$(CONSOLE) translation:extract --format=yaml --force --clean en_GB
 	$(CONSOLE) translation:extract --format=yaml --force --clean fr_FR
+	# Restore the security files as keys are removed from them whereas they should not.
+	git restore translations/security+intl-icu.*
 
 .PHONY: migration
 migration: ## Generate a database migration from entities changes


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make translations` → check the `translations/security*` files aren't changed

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [ ] code is manually tested
- [ ] permissions / authorizations are verified
- [ ] interface works on both mobiles and big screens
- [ ] interface works in both light and dark modes
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up-to-date
- [ ] documentation is up-to-date (including migration notes)
