### PR TITLE
fix: Set correct inline attachments URLs in messages contents

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@
 
 APP_ENV=dev
 APP_SECRET=97cb420d0d43c4c786c51225db0b6018
+APP_BASE_URL=http://localhost:8000
 
 DATABASE_URL="postgresql://postgres:postgres@pgsql:5432/bileto?serverVersion=11&charset=utf8"
 # DATABASE_URL="mysql://root:mariadb@mariadb:3306/bileto?serverVersion=10.4.29-MariaDB"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog of Bileto
 
+## unreleased
+
+### Migration notes
+
+You need to set the new environment variable `APP_BASE_URL` in your `.env.local` file (see [env.sample](/env.sample)).
+This variable is used to generate absolute URLs in non-HTTP contexts (i.e. from the command line).
+
 ## 2023-11-23 - 0.6.0-alpha
 
 ### New

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -8,7 +8,7 @@ framework:
 
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(APP_BASE_URL)%'
 
 when@prod:
     framework:

--- a/env.sample
+++ b/env.sample
@@ -12,6 +12,10 @@ APP_ENV=prod
 # Generate a token with the command: php bin/console app:secret
 APP_SECRET=change-me
 
+# The base URL that serves your application. It is used to generate URLs in
+# non-HTTP contexts (i.e. from the command line).
+APP_BASE_URL=https://example.org
+
 # The path to the upload directory.
 # Default is uploads/ in the root directory.
 # APP_UPLOADS_DIRECTORY=/path/to/uploads

--- a/src/Repository/MessageDocumentRepository.php
+++ b/src/Repository/MessageDocumentRepository.php
@@ -36,6 +36,20 @@ class MessageDocumentRepository extends ServiceEntityRepository implements UidGe
         }
     }
 
+    /**
+     * @param MessageDocument[] $entities
+     */
+    public function saveBatch(array $entities, bool $flush = false): void
+    {
+        foreach ($entities as $entity) {
+            $this->save($entity, false);
+        }
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
     public function remove(MessageDocument $entity, bool $flush = false): void
     {
         $this->getEntityManager()->remove($entity);


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/436

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- configure a mailbox (see https://github.com/Probesys/bileto/blob/main/docs/developers/greenmail.md#in-bileto)
- send a mail to the mailbox with an image inlined in the content
- wait for the collector to fetch the email and create a ticket from it
- check that the image appears in the content

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
