### PR TITLE
Update CreateCommand.php

### DIFF
--- a/src/Command/Users/CreateCommand.php
+++ b/src/Command/Users/CreateCommand.php
@@ -60,12 +60,13 @@ class CreateCommand extends Command
     }
 
     protected function configure(): void
-    {
-        $this
-            ->addOption('email', '', InputOption::VALUE_OPTIONAL, 'The email of the user.')
-            ->addOption('password', '', InputOption::VALUE_OPTIONAL, 'The password of the user.')
-        ;
-    }
+{
+    $this
+        ->addOption('email', '', InputOption::VALUE_OPTIONAL, 'The email of the user.')
+        ->addOption('password', '', InputOption::VALUE_OPTIONAL, 'The password of the user.')
+        ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'The language of the user (en_GB or fr_FR).', 'en_GB');
+}
+
 
     protected function interact(InputInterface $input, OutputInterface $output): void
     {


### PR DESCRIPTION
feat: Allow language selection in CreateCommand

- Added a new optional --language option to the CreateCommand
- Default language set to en_GB for user creation via command line

## Related issue(s)
https://github.com/Probesys/bileto/issues/490
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

## How to test manually 
N/A
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

## Checklist
N/A
<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [ ] interface works in both light and dark modes
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up-to-date
- [ ] documentation is up-to-date (including migration notes)
