### PR TITLE
fix: Fix various encoding issues in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 You need to set the new environment variable `APP_BASE_URL` in your `.env.local` file (see [env.sample](/env.sample)).
 This variable is used to generate absolute URLs in non-HTTP contexts (i.e. from the command line).
 
+The PHP `imap` module is now required.
+Bileto uses [PHP-IMAP](https://github.com/Webklex/php-imap) which should make the module optional.
+Unfortunately, the library doesn't decode email subjects and attachments correctly by itself.
+It works a lot better with the module installed.
+
 ## 2023-11-23 - 0.6.0-alpha
 
 ### New

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-imap": "*",
         "ext-intl": "*",
         "ext-ldap": "*",
         "ext-pdo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "074a75c15ffa04158f2cae54da7d4179",
+    "content-hash": "ad8dc12b2e7b6f7889198a371085e239",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -10131,6 +10131,7 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-imap": "*",
         "ext-intl": "*",
         "ext-ldap": "*",
         "ext-pdo": "*",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,9 @@ ENV COMPOSER_HOME /tmp
 
 RUN apt-get update && apt-get install -y \
     git \
+    libc-client-dev \
     libicu-dev \
+    libkrb5-dev \
     libldap-dev  \
     libpq-dev \
     libxslt-dev \
@@ -16,7 +18,8 @@ RUN apt-get update && apt-get install -y \
     unzip \
   && pecl install xdebug \
   && docker-php-ext-configure intl \
-  && docker-php-ext-install -j$(nproc) intl ldap pdo pdo_mysql pdo_pgsql xsl zip \
+  && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+  && docker-php-ext-install -j$(nproc) imap intl ldap pdo pdo_mysql pdo_pgsql xsl zip \
   && docker-php-ext-enable xdebug \
   && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
 

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -44,13 +44,17 @@ COPY docker/production/apache.conf /etc/apache2/sites-available/000-default.conf
 # Install the dependencies
 RUN apt-get update \
     && apt-get install -y \
+        libc-client-dev \
         libicu-dev \
+        libkrb5-dev \
         libldap-dev  \
         libpq-dev \
         libxslt-dev \
         libzip-dev \
         unzip \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install -j$(nproc) \
+        imap \
         intl \
         ldap \
         pdo \

--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -153,14 +153,7 @@ class MailboxEmail implements MetaEntityInterface, ActivityRecordableInterface
 
     public function getSubject(): string
     {
-        $subject = $this->getEmail()->getSubject();
-        $decodedSubject = iconv_mime_decode($subject, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, "UTF-8");
-
-        if ($decodedSubject === false) {
-            return $subject;
-        }
-
-        return $decodedSubject;
+        return $this->getEmail()->getSubject();
     }
 
     public function getBody(): string

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -231,6 +231,17 @@ class CreateTicketsFromMailboxEmailsHandler
     private function replaceAttachmentsUrls(string $content, array $messageDocuments): string
     {
         $contentDom = new \DOMDocument();
+
+        // DOMDocument::loadHTML considers the source string to be encoded in
+        // ISO-8859-1 by default. In order to not ending with weird characters,
+        // we encode the non-ASCII chars (i.e. all chars above >0x80) to HTML
+        // entities.
+        $content = mb_encode_numericentity(
+            $content,
+            [0x80, 0x10FFFF, 0, -1],
+            'UTF-8'
+        );
+
         $contentDom->loadHTML($content);
         $contentDomXPath = new \DomXPath($contentDom);
 

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -230,6 +230,10 @@ class CreateTicketsFromMailboxEmailsHandler
      */
     private function replaceAttachmentsUrls(string $content, array $messageDocuments): string
     {
+        if (!$content) {
+            return '';
+        }
+
         $contentDom = new \DOMDocument();
 
         // DOMDocument::loadHTML considers the source string to be encoded in

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -197,6 +197,11 @@ class CreateTicketsFromMailboxEmailsHandler
         foreach ($mailboxEmail->getAttachments() as $attachment) {
             $id = $attachment->getId();
             $filename = $attachment->getName();
+            // PHP-IMAP can return invalid UTF-8 characters in some circumstances.
+            // mb_convert_encoding will replace these characters with the
+            // character "?".
+            // Bug issue: https://github.com/Webklex/php-imap/issues/459
+            $filename = mb_convert_encoding($filename, 'UTF-8', 'UTF-8');
             $status = $attachment->save($tmpPath, $filename);
 
             if (!$status) {


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/488

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- configure the email address alix@example.com in both Thunderbird and Gnome Evolution if possible (in order to send emails to support@example.com with both email clients)
- create a file named `café.txt` (ex. `echo 'Hello World' > café.txt`)
- in each email clients:
    - send an HTML email containing at least an accent in the subject and in the body, and attach the file `café.txt` to it
    - collect the emails from the support@example.com mailbox
    - check that the subject, the body and the filename of the attachment are displayed correctly in the ticket (note: the attachment sent with Evolution should appear as `caf?.txt` due to a bug in PHP-IMAP, see https://github.com/Webklex/php-imap/issues/459)
    - send an empty email (choose whatever subject you want)
    - collect the emails from the support@example.com mailbox
    - check it works (collecting was failing before that)

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it. -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up-to-date
- [x] documentation is up-to-date (including migration notes)
