### PR TITLE
fix: Wrap pre elements in messages contents

### DIFF
--- a/assets/stylesheets/components/messages.css
+++ b/assets/stylesheets/components/messages.css
@@ -201,6 +201,10 @@
     border-left: var(--width-border-bold) solid var(--color-primary6);
 }
 
+.message__content pre {
+    white-space: pre-wrap;
+}
+
 .message__bottom {
     padding: 2rem;
 


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. send an email with a long line in a `pre` element
2. fetch the emails → check the line is wrapped and doesn't extend the message, breaking the interface

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
