### PR TITLE
i18n: Remove the Orphan parenthesis from the incident_updated_on key

### DIFF
--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -299,7 +299,7 @@ tickets.index.title.to_assign: 'Tickets to assign'
 tickets.index.title.your_tickets: 'Your tickets'
 tickets.involves: Involves
 tickets.list.incident_opened_on: 'Incident opened on <time datetime="{dateIso}">{date}</time>'
-tickets.list.incident_updated_on: 'Incident updated on <time datetime="{dateIso}">{date}</time>)'
+tickets.list.incident_updated_on: 'Incident updated on <time datetime="{dateIso}">{date}</time>'
 tickets.list.request_opened_on: 'Request opened on <time datetime="{dateIso}">{date}</time>'
 tickets.list.request_updated_on: 'Request updated on <time datetime="{dateIso}">{date}</time>'
 tickets.new.choose_orga: 'Choose an organization'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/498

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- Connect yourself
- Go to preferences
- Change the language in English
- Update a ticket (Add or change any informations)
- Go to .../tickets
- Check that there is no orphan parenthesis at the end of "Incident updated on..."

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
