### PR TITLE
imp: Warn if user has no permission in their default organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docker-build: ## Rebuild Docker containers
 
 .PHONY: docker-clean
 docker-clean: ## Clean the Docker stuff
-	$(DOCKER_COMPOSE) down
+	$(DOCKER_COMPOSE) --profile pgsql --profile mariadb --profile ldap down -v
 
 .PHONY: docker-image
 docker-image: ## Build the Docker image for production (take a VERSION argument)

--- a/assets/stylesheets/components/alerts.css
+++ b/assets/stylesheets/components/alerts.css
@@ -69,3 +69,7 @@
 .alert__message {
     margin-top: 0.5rem;
 }
+
+.alert__message a {
+    color: currentcolor;
+}

--- a/src/Controller/Users/AuthorizationsController.php
+++ b/src/Controller/Users/AuthorizationsController.php
@@ -46,6 +46,7 @@ class AuthorizationsController extends BaseController
     #[Route('/users/{uid}/authorizations/new', name: 'new user authorization', methods: ['GET', 'HEAD'])]
     public function new(
         User $holder,
+        Request $request,
         OrganizationRepository $organizationRepository,
         RoleRepository $roleRepository,
         OrganizationSorter $organizationSorter,
@@ -53,6 +54,9 @@ class AuthorizationsController extends BaseController
         Authorizer $authorizer,
     ): Response {
         $this->denyAccessUnlessGranted('admin:manage:users');
+
+        /** @var string $defaultOrganizationUid */
+        $defaultOrganizationUid = $request->query->get('orga', '');
 
         $organizations = $organizationRepository->findAll();
         $organizations = $organizationSorter->asTree($organizations);
@@ -71,7 +75,7 @@ class AuthorizationsController extends BaseController
             'user' => $holder,
             'type' => 'user',
             'roleUid' => '',
-            'organizationUid' => '',
+            'organizationUid' => $defaultOrganizationUid,
         ]);
     }
 

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -124,9 +124,15 @@ class UsersController extends BaseController
 
         $userRepository->save($newUser, true);
 
-        return $this->redirectToRoute('new user authorization', [
+        $parameters = [
             'uid' => $newUser->getUid(),
-        ]);
+        ];
+
+        if ($organization !== null) {
+            $parameters['orga'] = $organization->getUid();
+        }
+
+        return $this->redirectToRoute('new user authorization', $parameters);
     }
 
     #[Route('/users/{uid}/edit', name: 'edit user', methods: ['GET', 'HEAD'])]

--- a/templates/users/authorizations/index.html.twig
+++ b/templates/users/authorizations/index.html.twig
@@ -22,6 +22,19 @@
         </div>
 
         <div class="wrapper wrapper--large flow">
+            {% if user.organization and not is_granted_to_user(user, 'orga:create:tickets', user.organization) %}
+                <div class="wrapper wrapper--text">
+                    {{ include('alerts/_alert.html.twig', {
+                        type: 'warning',
+                        title: 'common.warning' | trans,
+                        message: 'users.no_organization_authorization' | trans({
+                            path: path('new user authorization', { uid: user.uid, orga: user.organization.uid }),
+                        }),
+                        raw: true,
+                    }) }}
+                </div>
+            {% endif %}
+
             <div class="grid">
                 <a class="card card--action" href="{{ path('new user authorization', { uid: user.uid }) }}">
                     <span>

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -201,6 +201,17 @@
                         with_context = false
                     ) }}
                 </select>
+
+                {% if user.organization and not is_granted_to_user(user, 'orga:create:tickets', user.organization) %}
+                    {{ include('alerts/_alert.html.twig', {
+                        type: 'warning',
+                        title: 'common.warning' | trans,
+                        message: 'users.no_organization_authorization' | trans({
+                            path: path('new user authorization', { uid: user.uid, orga: user.organization.uid }),
+                        }),
+                        raw: true,
+                    }) }}
+                {% endif %}
             </div>
 
             <div class="form__actions">

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -110,7 +110,10 @@ class UsersControllerTest extends WebTestCase
 
         $this->assertSame(2, UserFactory::count());
         $newUser = UserFactory::last();
-        $this->assertResponseRedirects("/users/{$newUser->getUid()}/authorizations/new", 302);
+        $this->assertResponseRedirects(
+            "/users/{$newUser->getUid()}/authorizations/new?orga={$organization->getUid()}",
+            302
+        );
         $this->assertSame($email, $newUser->getEmail());
         $this->assertSame($name, $newUser->getName());
         $this->assertSame($user->getLocale(), $newUser->getLocale());

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -47,6 +47,7 @@ advanced_search_syntax.qualifiers.type.example1: 'Tickets of type “incident”
 advanced_search_syntax.qualifiers.type.title: Type
 advanced_search_syntax.qualifiers.type.values: 'The possible values for “type“ are: <code>incident</code> and <code>request</code>.'
 advanced_search_syntax.title: 'Quick reference for the advanced syntax'
+common.warning: Warning
 contracts.alerts.edit.date_alert.after: 'days before the end of the contract.'
 contracts.alerts.edit.date_alert.before: Alert
 contracts.alerts.edit.hours_alert.after: '% of the hours have been consumed.'
@@ -421,6 +422,7 @@ users.new.leave_password_empty: '(leave empty to forbid login)'
 users.new.organization_caption: 'The tickets opened by email by this user will be attached to this organization.'
 users.new.submit: 'Create the user'
 users.new.title: 'New user'
+users.no_organization_authorization: 'This user cannot create tickets in their organisation by default. Remember to <a href="{path}">give this user the appropriate authorization.</a>'
 users.no_organization: 'No organization'
 users.organization: Organization
 users.password: Password

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -47,6 +47,7 @@ advanced_search_syntax.qualifiers.type.example1: "Les tickets de type «\_incide
 advanced_search_syntax.qualifiers.type.title: Type
 advanced_search_syntax.qualifiers.type.values: "Les valeurs possibles pour «\_type\_» sont\_: <code>incident</code> et <code>request</code>."
 advanced_search_syntax.title: 'Aide-mémoire de la syntaxe avancée'
+common.warning: Attention
 contracts.alerts.edit.date_alert.after: 'jours de la fin du contrat.'
 contracts.alerts.edit.date_alert.before: 'Alerter à'
 contracts.alerts.edit.hours_alert.after: '% des heures seront consommées.'
@@ -421,6 +422,7 @@ users.new.leave_password_empty: '(laissez vide pour empêcher la connexion)'
 users.new.organization_caption: 'Les tickets ouverts par email par cet utilisateur seront attachés à cette organisation.'
 users.new.submit: 'Créer l’utilisateur'
 users.new.title: 'Nouvel utilisateur'
+users.no_organization_authorization: 'Cet utilisateur ne peut pas créer de tickets dans son organisation par défaut. Pensez à lui <a href="{path}">donner une autorisation correspondante.</a>'
 users.no_organization: 'Aucune organisation'
 users.organization: Organisation
 users.password: 'Mot de passe'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/566

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. create a user and set them a default organization
2. check that you're redirected to the new authorization of the user, and that the default organization is selected
3. before submitting the form, return to the list of the authorizations
4. check that there's a warning about missing permission for the user in their default organization
5. return to the list of the users, and edit the new user
6. check there's a warning about the missing permission on the default organization field
7. click on the link in the warning
8. check that you're redirected to the new authorization form and that the default organization is selected
9. give the user an authorization (the role must be able to create a ticket)
10. check that you're redirected to the list of the authorizations and that the warning isn't there anymore
11. return to the edition form of the user, and check the warning isn't there neither

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
