### PR TITLE
imp: Change wording from billed/charged to accounted time

### DIFF
--- a/migrations/Version20240201145738RenameContractBillingIntervalToTimeAccountingUnit.php
+++ b/migrations/Version20240201145738RenameContractBillingIntervalToTimeAccountingUnit.php
@@ -1,0 +1,42 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240201145738RenameContractBillingIntervalToTimeAccountingUnit extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename the contract billingInterval column to timeAccountingUnit.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE contract RENAME COLUMN billing_interval TO time_accounting_unit');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE contract CHANGE billing_interval time_accounting_unit INT DEFAULT 0 NOT NULL');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE contract RENAME COLUMN time_accounting_unit TO billing_interval');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE contract CHANGE time_accounting_unit billing_interval INT DEFAULT 0 NOT NULL');
+        }
+    }
+}

--- a/src/Controller/Tickets/ContractsController.php
+++ b/src/Controller/Tickets/ContractsController.php
@@ -14,7 +14,7 @@ use App\Repository\EntityEventRepository;
 use App\Repository\TicketRepository;
 use App\Repository\TimeSpentRepository;
 use App\Service\Sorter\ContractSorter;
-use App\Service\ContractBilling;
+use App\Service\ContractTimeAccounting;
 use App\Utils\ConstraintErrorsFormatter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -58,7 +58,7 @@ class ContractsController extends BaseController
         EntityEventRepository $entityEventRepository,
         TicketRepository $ticketRepository,
         TimeSpentRepository $timeSpentRepository,
-        ContractBilling $contractBilling,
+        ContractTimeAccounting $contractTimeAccounting,
         ContractSorter $contractSorter,
         TranslatorInterface $translator,
     ): Response {
@@ -74,7 +74,7 @@ class ContractsController extends BaseController
 
         $ongoingContractUid = $request->request->getString('ongoingContractUid');
 
-        $chargeTimeSpent = $request->request->getBoolean('chargeTimeSpent');
+        $includeUnaccountedTime = $request->request->getBoolean('includeUnaccountedTime');
 
         $csrfToken = $request->request->getString('_csrf_token');
 
@@ -126,9 +126,9 @@ class ContractsController extends BaseController
             $entityEventRepository->save($entityEvent, true);
         }
 
-        if ($chargeTimeSpent && $newOngoingContract) {
-            $timeSpents = $ticket->getTimeSpentsNotCharged()->getValues();
-            $contractBilling->chargeTimeSpents($newOngoingContract, $timeSpents);
+        if ($includeUnaccountedTime && $newOngoingContract) {
+            $timeSpents = $ticket->getUnaccountedTimeSpents()->getValues();
+            $contractTimeAccounting->accountTimeSpents($newOngoingContract, $timeSpents);
             $timeSpentRepository->saveBatch($timeSpents, true);
         }
 

--- a/src/Entity/Contract.php
+++ b/src/Entity/Contract.php
@@ -105,7 +105,7 @@ class Contract implements MonitorableEntityInterface, UidEntityInterface
     private Collection $timeSpents;
 
     #[ORM\Column(options: ["default" => 0])]
-    private ?int $billingInterval = null;
+    private ?int $timeAccountingUnit = null;
 
     #[ORM\Column(options: ['default' => 0])]
     private ?int $hoursAlert = null;
@@ -121,7 +121,7 @@ class Contract implements MonitorableEntityInterface, UidEntityInterface
         $this->maxHours = 10;
         $this->startAt = Utils\Time::now();
         $this->endAt = Utils\Time::relative('last day of december');
-        $this->billingInterval = 0;
+        $this->timeAccountingUnit = 0;
         $this->notes = '';
         $this->hoursAlert = 0;
         $this->dateAlert = 0;
@@ -349,14 +349,14 @@ class Contract implements MonitorableEntityInterface, UidEntityInterface
         return $this;
     }
 
-    public function getBillingInterval(): ?int
+    public function getTimeAccountingUnit(): ?int
     {
-        return $this->billingInterval;
+        return $this->timeAccountingUnit;
     }
 
-    public function setBillingInterval(int $billingInterval): static
+    public function setTimeAccountingUnit(int $timeAccountingUnit): static
     {
-        $this->billingInterval = $billingInterval;
+        $this->timeAccountingUnit = $timeAccountingUnit;
 
         return $this;
     }
@@ -457,7 +457,7 @@ class Contract implements MonitorableEntityInterface, UidEntityInterface
         $contract->setStartAt($startAt);
         $endAt = $startAt->modify('last day of december');
         $contract->setEndAt($endAt);
-        $contract->setBillingInterval($this->getBillingInterval());
+        $contract->setTimeAccountingUnit($this->getTimeAccountingUnit());
         $contract->setNotes($this->getNotes());
         $contract->setHoursAlert($this->getHoursAlert());
         $contract->setDateAlert($this->getDateAlert());

--- a/src/Entity/Ticket.php
+++ b/src/Entity/Ticket.php
@@ -465,7 +465,7 @@ class Ticket implements MonitorableEntityInterface, UidEntityInterface
     /**
      * @return Collection<int, TimeSpent>
      */
-    public function getTimeSpentsNotCharged(): Collection
+    public function getUnaccountedTimeSpents(): Collection
     {
         $criteria = Criteria::create();
         $expr = Criteria::expr()->isNull('contract');

--- a/src/Form/Type/ContractType.php
+++ b/src/Form/Type/ContractType.php
@@ -34,7 +34,7 @@ class ContractType extends AbstractType
         $builder->add('maxHours', Type\IntegerType::class, [
             'empty_data' => '0',
         ]);
-        $builder->add('billingInterval', Type\IntegerType::class, [
+        $builder->add('timeAccountingUnit', Type\IntegerType::class, [
             'required' => false,
             'empty_data' => '0',
         ]);

--- a/templates/contracts/_form.html.twig
+++ b/templates/contracts/_form.html.twig
@@ -104,32 +104,32 @@
     </div>
 
     <div class="flow flow--small">
-        <label for="{{ field_id(form.billingInterval) }}">
-            {{ 'contracts.form.billing_interval' | trans }}
+        <label for="{{ field_id(form.timeAccountingUnit) }}">
+            {{ 'contracts.form.time_accounting_unit' | trans }}
 
             <small class="text--secondary">
                 {{ 'forms.optional' | trans }}
             </small>
         </label>
 
-        <p class="form__caption" id="{{ field_id(form.billingInterval, 'caption') }}">
-            {{ 'contracts.form.billing_interval.caption' | trans }}
+        <p class="form__caption" id="{{ field_id(form.timeAccountingUnit, 'caption') }}">
+            {{ 'contracts.form.time_accounting_unit.caption' | trans }}
         </p>
 
-        {{ form_errors(form.billingInterval) }}
+        {{ form_errors(form.timeAccountingUnit) }}
 
         <input
             type="number"
-            id="{{ field_id(form.billingInterval) }}"
-            name="{{ field_name(form.billingInterval) }}"
-            value="{{ field_value(form.billingInterval) }}"
+            id="{{ field_id(form.timeAccountingUnit) }}"
+            name="{{ field_name(form.timeAccountingUnit) }}"
+            value="{{ field_value(form.timeAccountingUnit) }}"
             min="0"
             step="1"
             class="input--size3"
-            aria-describedby="{{ field_id(form.billingInterval, 'caption') }}"
-            {% if field_has_errors(form.billingInterval) %}
+            aria-describedby="{{ field_id(form.timeAccountingUnit, 'caption') }}"
+            {% if field_has_errors(form.timeAccountingUnit) %}
                 aria-invalid="true"
-                aria-errormessage="{{ field_id(form.billingInterval, 'error') }}"
+                aria-errormessage="{{ field_id(form.timeAccountingUnit, 'error') }}"
             {% endif %}
         />
     </div>

--- a/templates/contracts/show.html.twig
+++ b/templates/contracts/show.html.twig
@@ -68,9 +68,9 @@
                 {% endif %}
             </div>
 
-            {% if contract.billingInterval %}
+            {% if contract.timeAccountingUnit %}
                 <p>
-                    {{ 'contracts.show.billing_interval' | trans({ count: contract.billingInterval }) }}
+                    {{ 'contracts.show.time_accounting_unit' | trans({ count: contract.timeAccountingUnit }) }}
                 </p>
             {% endif %}
 

--- a/templates/tickets/_timeline_time_spent.html.twig
+++ b/templates/tickets/_timeline_time_spent.html.twig
@@ -10,11 +10,11 @@
 
         {% if timeSpent.contract is null %}
             <span class="text--secondary text--small">
-                {{ 'tickets.show.time_spent.not_charged' | trans }}
+                {{ 'tickets.show.time_spent.unaccounted' | trans }}
             </span>
         {% elseif timeSpent.realTime != timeSpent.time %}
             <span class="text--secondary text--small">
-                {{ 'tickets.show.time_spent.charged' | trans({ count: timeSpent.time }) }}
+                {{ 'tickets.show.time_spent.accounted' | trans({ count: timeSpent.time }) }}
             </span>
         {% endif %}
     </div>

--- a/templates/tickets/contracts/edit.html.twig
+++ b/templates/tickets/contracts/edit.html.twig
@@ -45,12 +45,12 @@
         <div>
             <input
                 type="checkbox"
-                id="charge-time-spent"
-                name="chargeTimeSpent"
+                id="include-unaccounted-time"
+                name="includeUnaccountedTime"
             />
 
-            <label for="charge-time-spent">
-                {{ 'tickets.contracts.edit.bill_not_charged_time_spent' | trans }}
+            <label for="include-unaccounted-time">
+                {{ 'tickets.contracts.edit.include_unaccounted_time' | trans }}
             </label>
         </div>
 

--- a/tests/Controller/Organizations/ContractsControllerTest.php
+++ b/tests/Controller/Organizations/ContractsControllerTest.php
@@ -138,7 +138,7 @@ class ContractsControllerTest extends WebTestCase
         $maxHours = 10;
         $startAt = new \DateTimeImmutable('2023-09-01');
         $endAt = new \DateTimeImmutable('2023-12-31');
-        $billingInterval = 30;
+        $timeAccountingUnit = 30;
         $notes = 'Some notes';
 
         $this->assertSame(0, ContractFactory::count());
@@ -150,7 +150,7 @@ class ContractsControllerTest extends WebTestCase
                 'maxHours' => $maxHours,
                 'startAt' => $startAt->format('Y-m-d'),
                 'endAt' => $endAt->format('Y-m-d'),
-                'billingInterval' => $billingInterval,
+                'timeAccountingUnit' => $timeAccountingUnit,
                 'notes' => $notes,
             ],
         ]);
@@ -164,7 +164,7 @@ class ContractsControllerTest extends WebTestCase
         $this->assertEquals($startAt, $contract->getStartAt());
         $expectedEndAt = $endAt->modify('23:59:59');
         $this->assertEquals($expectedEndAt, $contract->getEndAt());
-        $this->assertSame($billingInterval, $contract->getBillingInterval());
+        $this->assertSame($timeAccountingUnit, $contract->getTimeAccountingUnit());
         $this->assertSame($notes, $contract->getNotes());
         $this->assertSame(80, $contract->getHoursAlert());
         $this->assertSame(24, $contract->getDateAlert()); // 20% of the days duration

--- a/tests/Controller/Tickets/MessagesControllerTest.php
+++ b/tests/Controller/Tickets/MessagesControllerTest.php
@@ -165,7 +165,7 @@ class MessagesControllerTest extends WebTestCase
             'startAt' => Time::ago(1, 'week'),
             'endAt' => Time::fromNow(1, 'week'),
             'maxHours' => 10,
-            'billingInterval' => 30,
+            'timeAccountingUnit' => 30,
         ]);
         $ticket = TicketFactory::createOne([
             'createdBy' => $user,

--- a/tests/Factory/ContractFactory.php
+++ b/tests/Factory/ContractFactory.php
@@ -65,7 +65,7 @@ final class ContractFactory extends ModelFactory
             'startAt' => $startAt,
             'endAt' => $endAt,
             'maxHours' => self::faker()->numberBetween(1, 9000),
-            'billingInterval' => 0,
+            'timeAccountingUnit' => 0,
             'hoursAlert' => 0,
             'dateAlert' => 0,
             'notes' => '',

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -55,8 +55,8 @@ contracts.alerts.edit.hours_alert.before: 'Alert when'
 contracts.alerts.edit.title: 'Set up contract alerts'
 contracts.days_consumed: "<strong>{days}\_d consumed</strong>"
 contracts.edit.title: 'Edit a contract'
-contracts.form.billing_interval: 'Billing interval in minutes'
-contracts.form.billing_interval.caption: 'The time spent on tickets will be rounded up for billing purposes (e.g. for 15 minutes of time spent, 30 minutes will be deducted for a corresponding billing interval).'
+contracts.form.time_accounting_unit: 'Time accounting unit (minutes)'
+contracts.form.time_accounting_unit.caption: 'The time spent on tickets will be rounded up for contractual purposes. For example, if the time accounting unit is 30 minutes, and a technician spends 15 minutes on a ticket, 30 minutes will be accounted for in the contract.'
 contracts.form.end_at: 'End on'
 contracts.form.max_hours: 'Max number of hours'
 contracts.form.name: Name
@@ -74,7 +74,7 @@ contracts.new.title: 'New contract'
 contracts.notes: 'Private notes'
 contracts.show.actions: Actions
 contracts.show.alert: Alert
-contracts.show.billing_interval: 'Billing interval: {count, plural, one {1 minute} other {# minutes}}'
+contracts.show.time_accounting_unit: 'Time accounting unit: {count, plural, one {1 minute} other {# minutes}}'
 contracts.show.edit: 'Edit the contract'
 contracts.show.notes_confidential: confidential
 contracts.show.renew: Renew
@@ -245,7 +245,7 @@ settings.index.title: Settings
 tickets.actors: Actors
 tickets.actors.edit.title: 'Edit the actors'
 tickets.assignee: Assignee
-tickets.contracts.edit.bill_not_charged_time_spent: 'Bill on this contract any unbilled time spent'
+tickets.contracts.edit.include_unaccounted_time: 'Include unaccounted time in the contract'
 tickets.contracts.edit.title: 'Edit the contract'
 tickets.contracts.none: 'No contract'
 tickets.contracts.ongoing: 'Ongoing contract'
@@ -354,8 +354,8 @@ tickets.show.resolved: 'This ticket is resolved.'
 tickets.show.scroll_to_bottom: 'Scroll to bottom'
 tickets.show.show_history: 'Show history'
 tickets.show.time_spent: "{count, plural, one {1\_minute spent} other {#\_minutes spent}}"
-tickets.show.time_spent.charged: "({count, plural, one {1\_minute charged} other {#\_minutes charged}})"
-tickets.show.time_spent.not_charged: '(not charged)'
+tickets.show.time_spent.accounted: "({count, plural, one {1\_minute accounted} other {#\_minutes accounted}})"
+tickets.show.time_spent.unaccounted: (unaccounted)
 tickets.show.urgency: 'Urgency:'
 tickets.sidebar.title: 'Your views'
 tickets.sort.alphabetical: 'Alphabetical order'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -55,8 +55,8 @@ contracts.alerts.edit.hours_alert.before: 'Alerter lorsque'
 contracts.alerts.edit.title: 'Configurer les alertes du contrat'
 contracts.days_consumed: "<strong>{days, plural, =0 {0\_j consommé} one {1\_j consommé} other {#\_j consommés}}</strong>"
 contracts.edit.title: 'Modifier un contrat'
-contracts.form.billing_interval: 'Intervalle de facturation en minutes'
-contracts.form.billing_interval.caption: 'Le temps passé sur les tickets sera arrondi pour le décompte de la facturation (ex. pour 15 minutes de temps passés, 30 minutes seront décomptés pour un intervalle de facturation correspondant).'
+contracts.form.time_accounting_unit: 'Unité de comptabilisation du temps (minutes)'
+contracts.form.time_accounting_unit.caption: 'Le temps passé sur les tickets sera arrondi à l’unité supérieure à des fins contractuelles. Par exemple, si l’unité de comptabilisation du temps est de 30 minutes et qu’un technicien passe 15 minutes sur un ticket, 30 minutes seront comptabilisées dans le contrat.'
 contracts.form.end_at: 'Termine le'
 contracts.form.max_hours: 'Nombre max. d’heures'
 contracts.form.name: Nom
@@ -74,7 +74,7 @@ contracts.new.title: 'Nouveau contrat'
 contracts.notes: 'Notes privées'
 contracts.show.actions: Actions
 contracts.show.alert: Alerte
-contracts.show.billing_interval: "Intervalle de facturation\_: {count, plural, one {1 minute} other {# minutes}}"
+contracts.show.time_accounting_unit: "Unité de comptabilisation du temps\_: {count, plural, one {1 minute} other {# minutes}}"
 contracts.show.edit: 'Modifier le contrat'
 contracts.show.notes_confidential: confidentielles
 contracts.show.renew: Renouveler
@@ -245,7 +245,7 @@ settings.index.title: Gestion
 tickets.actors: Acteurs
 tickets.actors.edit.title: 'Modifier les acteurs'
 tickets.assignee: 'Attribué à'
-tickets.contracts.edit.bill_not_charged_time_spent: 'Facturer sur ce contrat les temps passés non facturés'
+tickets.contracts.edit.include_unaccounted_time: 'Inclure le temps non comptabilisé dans le contrat'
 tickets.contracts.edit.title: 'Modifier le contrat'
 tickets.contracts.none: 'Aucun contrat'
 tickets.contracts.ongoing: 'Contrat en cours'
@@ -354,8 +354,8 @@ tickets.show.resolved: 'Ce ticket est résolu.'
 tickets.show.scroll_to_bottom: 'Défiler en bas'
 tickets.show.show_history: 'Afficher l’historique'
 tickets.show.time_spent: "{count, plural, one {1\_minute passée} other {#\_minutes passées}}"
-tickets.show.time_spent.charged: "({count, plural, one {1\_minute facturée} other {#\_minutes facturées}})"
-tickets.show.time_spent.not_charged: '(non facturées)'
+tickets.show.time_spent.accounted: "({count, plural, one {1\_minute comptabilisée} other {#\_minutes comptabilisées}})"
+tickets.show.time_spent.unaccounted: '(non comptabilisé)'
 tickets.show.urgency: "Urgence\_:"
 tickets.sidebar.title: 'Vos vues'
 tickets.sort.alphabetical: 'Ordre alphabétique'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

Resolve https://github.com/Probesys/bileto/issues/523

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- Create a contract → check that the "billing interval" field is renamed to "Time accounting unit" and the description is adapted (set the value to 30)
- Check the time accounting unit is displayed on the contract page
- Set the contract to a ticket → check that the checkbox is rephrased to "Include unaccounted time in the contract"
- Add an answer and spend time (less than 30 minutes, e.g. 10 minutes)
- Check the time is displayed as "10 minutes spent (30 minutes accounted) "

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
