### PR TITLE
505 display time spents in the ticket timeline formatted as hours

### DIFF
--- a/src/Twig/HoursFormatterExtension.php
+++ b/src/Twig/HoursFormatterExtension.php
@@ -30,41 +30,65 @@ class HoursFormatterExtension extends AbstractExtension
      *
      * Hours can be given as float. The decimal part of the number is
      * transformed to minutes. For instance, 2.5 will return "2h 30m".
+     *
+     * @param 'short'|'long' $format
      */
-    public function formatHours(int|float $hours): string
+    public function formatHours(int|float $hours, string $format = 'short'): string
     {
         $hoursOnly = intval(floor($hours));
         $minutes = intval(($hours - $hoursOnly) * 60);
 
-        return $this->format($hoursOnly, $minutes);
+        return $this->format($hoursOnly, $minutes, $format);
     }
 
     /**
      * Return the given minutes formatted as hours and minutes.
+     *
+     * @param 'short'|'long' $format
      */
-    public function formatMinutes(int $minutes): string
+    public function formatMinutes(int $minutes, string $format = 'short'): string
     {
         $hours = intdiv($minutes, 60);
         $remainingMinutes = $minutes % 60;
 
-        return $this->format($hours, $remainingMinutes);
+        return $this->format($hours, $remainingMinutes, $format);
     }
 
-    private function format(int $hours, int $minutes): string
+    /**
+     * @param 'short'|'long' $format
+     */
+    private function format(int $hours, int $minutes, string $format = 'short'): string
     {
-        if ($minutes === 0) {
-            return $this->translator->trans('hours_formatter.hours', [
-                'hours' => $hours,
-            ]);
-        } elseif ($hours === 0) {
-            return $this->translator->trans('hours_formatter.minutes', [
-                'minutes' => $minutes,
-            ]);
+        if ($format === 'long') {
+            if ($minutes === 0) {
+                return $this->translator->trans('hours_formatter.hours.long', [
+                    'hours' => $hours,
+                ]);
+            } elseif ($hours === 0) {
+                return $this->translator->trans('hours_formatter.minutes.long', [
+                    'minutes' => $minutes,
+                ]);
+            } else {
+                return $this->translator->trans('hours_formatter.hours_and_minutes.long', [
+                    'hours' => $hours,
+                    'minutes' => $minutes,
+                ]);
+            }
         } else {
-            return $this->translator->trans('hours_formatter.hours_and_minutes', [
-                'hours' => $hours,
-                'minutes' => $minutes,
-            ]);
+            if ($minutes === 0) {
+                return $this->translator->trans('hours_formatter.hours.short', [
+                    'hours' => $hours,
+                ]);
+            } elseif ($hours === 0) {
+                return $this->translator->trans('hours_formatter.minutes.short', [
+                    'minutes' => $minutes,
+                ]);
+            } else {
+                return $this->translator->trans('hours_formatter.hours_and_minutes.short', [
+                    'hours' => $hours,
+                    'minutes' => $minutes,
+                ]);
+            }
         }
     }
 }

--- a/templates/tickets/_timeline_time_spent.html.twig
+++ b/templates/tickets/_timeline_time_spent.html.twig
@@ -6,7 +6,7 @@
 
 <div class="timeline__time-spent" data-test="time-spent-item">
     <div class="timeline__time-spent-message">
-        {{ 'tickets.show.time_spent' | trans({ count: timeSpent.realTime }) }}
+        {{ 'tickets.show.time_spent' | trans({ count: timeSpent.realTime | formatMinutes('long') }) }}
 
         {% if timeSpent.contract is null %}
             <span class="text--secondary text--small">
@@ -14,7 +14,7 @@
             </span>
         {% elseif timeSpent.realTime != timeSpent.time %}
             <span class="text--secondary text--small">
-                {{ 'tickets.show.time_spent.accounted' | trans({ count: timeSpent.time }) }}
+                {{ 'tickets.show.time_spent.accounted' | trans({ count: timeSpent.time | formatMinutes('long')  }) }}
             </span>
         {% endif %}
     </div>

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -110,9 +110,12 @@ home.new_ticket: 'New ticket'
 home.no_tickets: 'No tickets'
 home.title: 'Welcome to Bileto'
 home.your_tickets: 'Your tickets'
-hours_formatter.hours: '{hours}h'
-hours_formatter.hours_and_minutes: "{hours}h\_{minutes}m"
-hours_formatter.minutes: '{minutes}m'
+hours_formatter.hours.long: "{ hours, plural, one {1\_hour} other {#\_hours} }"
+hours_formatter.hours.short: "{hours}\_h"
+hours_formatter.hours_and_minutes.long: "{ hours, plural, one {1\_hour} other {#\_hours} }\_{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.hours_and_minutes.short: "{hours}\_h\_{minutes}\_m"
+hours_formatter.minutes.long: "{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.minutes.short: "{minutes}\_m"
 layout.activate_javascript: 'You need to activate the JavaScript in order to use Bileto.'
 layout.home: Home
 layout.logout: Logout
@@ -390,8 +393,8 @@ tickets.show.refuse: Refuse
 tickets.show.resolved: 'This ticket is resolved.'
 tickets.show.scroll_to_bottom: 'Scroll to bottom'
 tickets.show.show_history: 'Show history'
-tickets.show.time_spent: "{count, plural, one {1\_minute spent} other {#\_minutes spent}}"
-tickets.show.time_spent.accounted: "({count, plural, one {1\_minute accounted} other {#\_minutes accounted}})"
+tickets.show.time_spent: '{count} spent'
+tickets.show.time_spent.accounted: '({ count } accounted)'
 tickets.show.time_spent.unaccounted: (unaccounted)
 tickets.show.urgency: 'Urgency:'
 tickets.sidebar.title: 'Your views'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -110,9 +110,12 @@ home.new_ticket: 'Nouveau ticket'
 home.no_tickets: 'Aucun ticket'
 home.title: 'Bienvenue sur Bileto'
 home.your_tickets: 'Vos tickets'
-hours_formatter.hours: '{hours}h'
-hours_formatter.hours_and_minutes: "{hours}h\_{minutes}m"
-hours_formatter.minutes: '{minutes}m'
+hours_formatter.hours.long: "{ hours, plural, one {1\_heure} other {#\_heures} }"
+hours_formatter.hours.short: "{hours}\_h"
+hours_formatter.hours_and_minutes.long: "{ hours, plural, one {1\_heure} other {#\_heures} }\_{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.hours_and_minutes.short: "{hours}\_h\_{minutes}\_m"
+hours_formatter.minutes.long: "{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.minutes.short: "{minutes}\_m"
 layout.activate_javascript: 'Vous devez activer le JavaScript pour utiliser Bileto.'
 layout.home: Accueil
 layout.logout: 'Se déconnecter'
@@ -390,9 +393,9 @@ tickets.show.refuse: Refuser
 tickets.show.resolved: 'Ce ticket est résolu.'
 tickets.show.scroll_to_bottom: 'Défiler en bas'
 tickets.show.show_history: 'Afficher l’historique'
-tickets.show.time_spent: "{count, plural, one {1\_minute passée} other {#\_minutes passées}}"
-tickets.show.time_spent.accounted: "({count, plural, one {1\_minute comptabilisée} other {#\_minutes comptabilisées}})"
-tickets.show.time_spent.unaccounted: '(non comptabilisé)'
+tickets.show.time_spent: '{count} passée(s)'
+tickets.show.time_spent.accounted: '({ count } comptabilisée(s))'
+tickets.show.time_spent.unaccounted: '(non comptabilisée(s))'
 tickets.show.urgency: "Urgence\_:"
 tickets.sidebar.title: 'Vos vues'
 tickets.sort.alphabetical: 'Ordre alphabétique'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->
#505 
## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->
- create a contract with a billing interval of 30 minutes
- attach the contract to a ticket
- answer to the ticket with spent time (e.g. 70 minutes)
- check the time is displayed as "1h 10m spent (1h 30m charged)"

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
