### PR TITLE
fix: Add the orga:manage to the default Technician role

### DIFF
--- a/src/Command/SeedsCommand.php
+++ b/src/Command/SeedsCommand.php
@@ -65,6 +65,7 @@ class SeedsCommand extends Command
                 'orga:create:tickets:messages',
                 'orga:create:tickets:messages:confidential',
                 'orga:create:tickets:time_spent',
+                'orga:manage',
                 'orga:see',
                 'orga:see:tickets:all',
                 'orga:see:tickets:contracts',


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/585

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make db-reset FORCE=true`
- check in the global settings that the technician role exists and has the "Manage the organization" permission

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [ ] code is manually tested
- [ ] permissions / authorizations are verified
- [ ] interface works on both mobiles and big screens
- [ ] interface works in both light and dark modes
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up to date
- [ ] documentation is up to date (including migration notes)
