### PR TITLE
 dev: Remove the warning about docker-compose.yml version

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -2,8 +2,6 @@
 # Copyright 2022-2024 Probesys
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: '3'
-
 services:
     php:
         image: bileto:php-dev

--- a/docs/administrators/docker.md
+++ b/docs/administrators/docker.md
@@ -54,8 +54,6 @@ Add the following YAML in your `docker-compose.yml`.
 You'll need to adapt its content.
 
 ```yml
-version: '3'
-
 services:
     bileto:
         image: ghcr.io/probesys/bileto:0.5.0-alpha


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Run `./docker/bin/php --version`
2. Check there is no warning (`WARN[0000] /path/to/bileto/docker/development/docker-compose.yml: version is obsolete`)

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
