### PR TITLE
imp: Display contract hours consumed as a percentage

### DIFF
--- a/src/Entity/Contract.php
+++ b/src/Entity/Contract.php
@@ -200,6 +200,13 @@ class Contract implements MonitorableEntityInterface, UidEntityInterface
         return $this->getConsumedMinutes() / 60;
     }
 
+    public function getConsumedPercentage(): float
+    {
+        $consumedHours = $this->getConsumedHours();
+        $maxHours = $this->getMaxHours();
+        return $consumedHours / $maxHours;
+    }
+
     public function getRemainingMinutes(): int
     {
         return ($this->getMaxHours() * 60) - $this->getConsumedMinutes();

--- a/templates/contracts/show.html.twig
+++ b/templates/contracts/show.html.twig
@@ -85,7 +85,11 @@
                         </span>
                     {% endif %}
 
-                    {{ 'contracts.hours_consumed' | trans({ 'hours': contract.consumedMinutes | formatMinutes, 'maxHours': contract.maxHours }) | raw }}
+                    {{ 'contracts.hours_consumed' | trans({
+                        'hours': contract.consumedMinutes | formatMinutes,
+                        'maxHours': contract.maxHours,
+                        'percentage': contract.consumedPercentage,
+                    }) | raw }}
                 </div>
 
                 <div class="progress-with-marker">

--- a/templates/organizations/contracts/index.html.twig
+++ b/templates/organizations/contracts/index.html.twig
@@ -67,7 +67,11 @@
 
                                 <div class="row row--baseline flow flow--smaller text--small">
                                     <div class="row__item--extend">
-                                        {{ 'contracts.hours_consumed' | trans({ 'hours': contract.consumedMinutes | formatMinutes, 'maxHours': contract.maxHours }) | raw }}
+                                        {{ 'contracts.hours_consumed' | trans({
+                                            'hours': contract.consumedMinutes | formatMinutes,
+                                            'maxHours': contract.maxHours,
+                                            'percentage': contract.consumedPercentage,
+                                        }) | raw }}
 
                                         ⋅
 

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -546,7 +546,11 @@
 
                             <div>
                                 <span class="text--small" id="contract-hours-consumed">
-                                    {{ 'contracts.hours_consumed' | trans({ 'hours': ongoingContract.consumedMinutes | formatMinutes, 'maxHours': ongoingContract.maxHours }) | raw }}
+                                    {{ 'contracts.hours_consumed' | trans({
+                                        'hours': ongoingContract.consumedMinutes | formatMinutes,
+                                        'maxHours': ongoingContract.maxHours,
+                                        'percentage': ongoingContract.consumedPercentage,
+                                    }) | raw }}
                                 </span>
 
                                 <progress value="{{ ongoingContract.consumedHours }}" max="{{ ongoingContract.maxHours }}" aria-labelledby="contract-hours-consumed">

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -73,7 +73,7 @@ contracts.form.name: Name
 contracts.form.new: 'Create the contract'
 contracts.form.notes: 'Private notes'
 contracts.form.start_at: 'Start on'
-contracts.hours_consumed: '<strong>{hours} consumed</strong> on {maxHours}h'
+contracts.hours_consumed: '<strong>{hours} consumed</strong> on {maxHours}h ({percentage, number, percent})'
 contracts.index.alert: Alert
 contracts.index.new_contract: 'New contract'
 contracts.index.no_contracts: 'No contracts'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -73,7 +73,7 @@ contracts.form.name: Nom
 contracts.form.new: 'Créer le contrat'
 contracts.form.notes: 'Notes privées'
 contracts.form.start_at: 'Démarre le'
-contracts.hours_consumed: "<strong>{hours} consommée(s)</strong> sur {maxHours}\_h"
+contracts.hours_consumed: "<strong>{hours} consommée(s)</strong> sur {maxHours}\_h ({percentage, number, percent})"
 contracts.index.alert: Alerte
 contracts.index.new_contract: 'Nouveau contrat'
 contracts.index.no_contracts: 'Aucun contrat'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/502

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->


1. Create a contract
2. Attach a ticket to the contract
3. Answer to the ticket with time spent
4. Check on the right column that the percentage of consumption of the contract is displayed
5. Go to the contract page, check the percentage is displayed as well
6. Go to the list of contracts, check the percentage is displayed as well

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
