### PR TITLE
imp: Display the contract date alert as a number of days

### DIFF
--- a/templates/contracts/show.html.twig
+++ b/templates/contracts/show.html.twig
@@ -156,8 +156,8 @@
                                 {{ 'contracts.show.alert' | trans }}
                             </span>
 
-                            <time datetime="{{ contract.dateOfAlert | dateIso }}">
-                                {{ contract.dateOfAlert | dateTrans('dd MMM') }}
+                            <time datetime="{{ contract.dateOfAlert | dateIso }}" title="{{ contract.dateOfAlert | dateTrans('dd MMM yyyy') }}">
+                                {{ 'contracts.show.alert.before_end' | trans({ days: contract.dateAlert }) | raw }}
                             </time>
                         </div>
                     {% endif %}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -83,6 +83,7 @@ contracts.index.title: Contracts
 contracts.new.title: 'New contract'
 contracts.notes: 'Private notes'
 contracts.show.alert: Alert
+contracts.show.alert.before_end: '{days} days<br>before end'
 contracts.show.time_accounting_unit: 'Time accounting unit: {count, plural, one {1 minute} other {# minutes}}'
 contracts.show.edit: 'Edit the contract'
 contracts.show.notes_confidential: confidential

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -83,6 +83,7 @@ contracts.index.title: Contrats
 contracts.new.title: 'Nouveau contrat'
 contracts.notes: 'Notes privées'
 contracts.show.alert: Alerte
+contracts.show.alert.before_end: '{days} jours<br>avant la fin'
 contracts.show.time_accounting_unit: "Unité de comptabilisation du temps\_: {count, plural, one {1 minute} other {# minutes}}"
 contracts.show.edit: 'Modifier le contrat'
 contracts.show.notes_confidential: confidentielles


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/503

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create a contract
2. Check there is a default alert on the progress bar of the date
3. Check the label of the alert indicates the number of days before the end of the contract
4. Hover the label and check it indicates the actual date of the alert

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
