### PR TITLE
imp: Rename global "Settings" to "Admin"

### DIFF
--- a/docs/developers/greenmail.md
+++ b/docs/developers/greenmail.md
@@ -31,7 +31,7 @@ $ ./docker/bin/console db:seeds:load
 ```
 
 You can configure more mailboxes with IMAP in the interface.
-As an admin, go to the “Settings > Mailboxes” and create a new mailbox.
+As an admin, go to the “Admin > Mailboxes” and create a new mailbox.
 Configure it with the following information:
 
 - name: whatever name you want

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -10,9 +10,9 @@ use App\Security\Authorizer;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class SettingsController extends BaseController
+class AdminController extends BaseController
 {
-    #[Route('/settings', name: 'settings', methods: ['GET', 'HEAD'])]
+    #[Route('/admin', name: 'admin', methods: ['GET', 'HEAD'])]
     public function index(Authorizer $authorizer): Response
     {
         $this->denyAccessUnlessGranted('admin:see');
@@ -34,6 +34,6 @@ class SettingsController extends BaseController
         // one of the previous admin permissions.
         // However, theorically, an admin role could be created without any
         // permission. The template will handle this case.
-        return $this->render('settings/index.html.twig');
+        return $this->render('admin/index.html.twig');
     }
 }

--- a/templates/admin.html.twig
+++ b/templates/admin.html.twig
@@ -6,13 +6,13 @@
 
 {% extends 'base.html.twig' %}
 
-{% set currentPage = 'settings' %}
+{% set currentPage = 'admin' %}
 
 {% block submenu %}
     <nav class="layout__submenu submenu" data-controller="submenu" aria-labelledby="submenu-title">
         <div class="cols cols--always cols--center">
             <div class="submenu__title col--extend" id="submenu-title">
-                {{ 'settings.index.title' | trans }}
+                {{ 'admin.index.title' | trans }}
             </div>
 
             <div class="submenu__scroller only-mobile">

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -6,19 +6,19 @@
 
 {% extends 'base.html.twig' %}
 
-{% set currentPage = 'settings' %}
+{% set currentPage = 'admin' %}
 
-{% block title %}{{ 'settings.index.title' | trans }}{% endblock %}
+{% block title %}{{ 'admin.index.title' | trans }}{% endblock %}
 
 {% block body %}
     <main class="layout__body flow flow--larger">
-        <h1>{{ 'settings.index.title' | trans }}</h1>
+        <h1>{{ 'admin.index.title' | trans }}</h1>
 
         <div class="wrapper wrapper--text wrapper--center">
             {{ include('alerts/_alert.html.twig', {
                 type: 'warning',
-                title: 'settings.index.no_access' | trans,
-                message: 'settings.index.no_access_advice' | trans,
+                title: 'admin.index.no_access' | trans,
+                message: 'admin.index.no_access_advice' | trans,
             }, with_context = false) }}
         </div>
     </main>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -177,10 +177,10 @@
                                         <li class="layout__header-item">
                                             <a
                                                 class="layout__header-anchor"
-                                                href="{{ path('settings') }}"
-                                                {{ currentPage == 'settings' ? 'aria-current="page"' }}
+                                                href="{{ path('admin') }}"
+                                                {{ currentPage == 'admin' ? 'aria-current="page"' }}
                                             >
-                                                {{ 'settings.index.title' | trans }}
+                                                {{ 'admin.index.title' | trans }}
                                             </a>
                                         </li>
                                     {% endif %}

--- a/templates/mailboxes/edit.html.twig
+++ b/templates/mailboxes/edit.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'mailboxes' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('mailboxes') }}">

--- a/templates/mailboxes/index.html.twig
+++ b/templates/mailboxes/index.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'mailboxes' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <span aria-current="page">

--- a/templates/mailboxes/new.html.twig
+++ b/templates/mailboxes/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'mailboxes' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('mailboxes') }}">

--- a/templates/roles/edit.html.twig
+++ b/templates/roles/edit.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'roles' %}
 
@@ -26,8 +26,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('roles') }}">

--- a/templates/roles/index.html.twig
+++ b/templates/roles/index.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'roles' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <span aria-current="page">

--- a/templates/roles/new.html.twig
+++ b/templates/roles/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'roles' %}
 
@@ -24,8 +24,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('roles') }}">

--- a/templates/teams/agents/new.html.twig
+++ b/templates/teams/agents/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('teams') }}">

--- a/templates/teams/authorizations/new.html.twig
+++ b/templates/teams/authorizations/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('teams') }}">

--- a/templates/teams/edit.html.twig
+++ b/templates/teams/edit.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('teams') }}">

--- a/templates/teams/index.html.twig
+++ b/templates/teams/index.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <span aria-current="page">

--- a/templates/teams/new.html.twig
+++ b/templates/teams/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('teams') }}">

--- a/templates/teams/show.html.twig
+++ b/templates/teams/show.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'teams' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('teams') }}">

--- a/templates/users/authorizations/index.html.twig
+++ b/templates/users/authorizations/index.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'users' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('users') }}">

--- a/templates/users/authorizations/new.html.twig
+++ b/templates/users/authorizations/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'users' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('users') }}">

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'users' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('users') }}">

--- a/templates/users/index.html.twig
+++ b/templates/users/index.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'users' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <span aria-current="page">

--- a/templates/users/new.html.twig
+++ b/templates/users/new.html.twig
@@ -4,7 +4,7 @@
  # SPDX-License-Identifier: AGPL-3.0-or-later
  #}
 
-{% extends 'settings.html.twig' %}
+{% extends 'admin.html.twig' %}
 
 {% set currentMenu = 'users' %}
 
@@ -16,8 +16,8 @@
             {{ 'layout.home' | trans }}
         </a>
 
-        <a href="{{ path('settings') }}">
-            {{ 'settings.index.title' | trans }}
+        <a href="{{ path('admin') }}">
+            {{ 'admin.index.title' | trans }}
         </a>
 
         <a href="{{ path('users') }}">

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
-class SettingsControllerTest extends WebTestCase
+class AdminControllerTest extends WebTestCase
 {
     use AuthorizationHelper;
     use Factories;
@@ -31,7 +31,7 @@ class SettingsControllerTest extends WebTestCase
             'admin:create:organizations',
         ]);
 
-        $client->request('GET', '/settings');
+        $client->request('GET', '/admin');
 
         $this->assertResponseRedirects('/roles', 302);
     }
@@ -47,7 +47,7 @@ class SettingsControllerTest extends WebTestCase
             'admin:create:organizations',
         ]);
 
-        $client->request('GET', '/settings');
+        $client->request('GET', '/admin');
 
         $this->assertResponseRedirects('/users', 302);
     }
@@ -61,7 +61,7 @@ class SettingsControllerTest extends WebTestCase
             'admin:see',
         ]);
 
-        $client->request('GET', '/settings');
+        $client->request('GET', '/admin');
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains(
@@ -79,6 +79,6 @@ class SettingsControllerTest extends WebTestCase
         $client->loginUser($user->object());
 
         $client->catchExceptions(false);
-        $client->request('GET', '/settings');
+        $client->request('GET', '/admin');
     }
 }

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -5,6 +5,9 @@ about.short: 'The ergonomic ticketing tool for managing your Help Desk.'
 about.source_code: 'source code'
 about.title: 'About Bileto'
 about.version: Version
+admin.index.no_access: 'You don’t have access to the administration.'
+admin.index.no_access_advice: 'Your administrator role has probably no permissions. You should contact another administrator to fix this.'
+admin.index.title: Admin
 advanced_search_syntax.complex.example1: 'Tickets with the word “emails” in their title and a priority of “high”.'
 advanced_search_syntax.complex.example2: 'Tickets with the status “new”, or those assigned to you'
 advanced_search_syntax.complex.example3: 'Tickets with the word “emails” in their title that have a “high” priority or that are assigned to you'
@@ -252,9 +255,6 @@ roles.super_admin.description: 'A special role with an access to all the adminis
 roles.type.admin: Administrator
 roles.type.agent: Agent
 roles.type.user: User
-settings.index.no_access: 'You don’t have access to the administration.'
-settings.index.no_access_advice: 'Your administrator role has probably no permissions. You should contact another administrator to fix this.'
-settings.index.title: Settings
 submenu.scroller.scroll_to_left: 'Scroll the menu to the left'
 submenu.scroller.scroll_to_right: 'Scroll the menu to the right'
 teams.agents.new.add_agent: 'Add the agent'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -5,6 +5,9 @@ about.short: 'L’outil de ticketing ergonomique pour votre gestion helpdesk.'
 about.source_code: 'code source'
 about.title: 'À propos de Bileto'
 about.version: Version
+admin.index.no_access: 'Vous n’avez pas accès à l’administration.'
+admin.index.no_access_advice: 'Votre rôle administrateur n’a probablement aucune permission. Vous devriez contacter un autre administrateur pour corriger cela.'
+admin.index.title: Admin
 advanced_search_syntax.complex.example1: "Les tickets contenant le mot «\_emails\_» dans leur titre et dont la priorité est «\_haute\_»"
 advanced_search_syntax.complex.example2: "Les tickets de statut «\_nouveau\_», ou ceux qui vous sont attribués"
 advanced_search_syntax.complex.example3: "Les tickets contenant le mot «\_emails\_» dans leur titre et dont la priorité est «\_haute\_» ou qui vous sont attribués"
@@ -252,9 +255,6 @@ roles.super_admin.description: 'Un rôle spécial avec un accès à toute l’ad
 roles.type.admin: Administrateur
 roles.type.agent: Agent
 roles.type.user: Utilisateur
-settings.index.no_access: 'Vous n’avez pas accès à l’administration.'
-settings.index.no_access_advice: 'Votre rôle administrateur n’a probablement aucune permission. Vous devriez contacter un autre administrateur pour corriger cela.'
-settings.index.title: Gestion
 submenu.scroller.scroll_to_left: 'Défile le menu vers la gauche'
 submenu.scroller.scroll_to_right: 'Défile le menu vers la droite'
 teams.agents.new.add_agent: 'Ajouter l’agent'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- login with a user who has admin access
- verify that "Settings" is now "Admin"
- navigate in different parts of the admin → verify the breadcrumb displays "Admin" instead of "Settings"

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
