### PR TITLE
fix: Display answer agent menu to all agents of the organization

### DIFF
--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -410,11 +410,11 @@
                                 {% endif %}
 
                                 {% set canPostSolutionApprovement = ticket.status == 'resolved' and ticket.requester == app.user %}
-                                {% set canSeeAgentMenu = not canPostSolutionApprovement and ticket.assignee == app.user %}
+                                {% set canSeeAgentMenu = not canPostSolutionApprovement and is_agent(organization) %}
 
                                 {% if canSeeAgentMenu %}
-                                    {% set canPostSolution = not ticket.isFinished and not ticket.hasSolution %}
-                                    {% set canPostTimeSpent = not ticket.isFinished and is_granted('orga:create:tickets:time_spent', organization) %}
+                                    {% set canPostSolution = not ticket.isFinished and not ticket.hasSolution and ticket.assignee == app.user %}
+                                    {% set canPostTimeSpent = is_granted('orga:create:tickets:time_spent', organization) %}
 
                                     <div class="cols flow">
                                         <div class="col--extend">


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/628

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- as an agent with all permissions, go to (or create) a ticket on which you're neither requester, nor assignee
- verify that you can add "spent time" and select "Confidential answer" (and post the answer)
- assign the ticket to yourself
- verify that you can select "Solution" (and post it)
- verify that you can still select "Confidential answer" and add "spent time"

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
