### PR TITLE
new: Allow to associate organizations to email domains

### DIFF
--- a/migrations/Version20240619153400AddDomainsToOrganization.php
+++ b/migrations/Version20240619153400AddDomainsToOrganization.php
@@ -1,0 +1,42 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240619153400AddDomainsToOrganization extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the domains column to the organization table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql("ALTER TABLE organization ADD domains JSON DEFAULT '[]' NOT NULL");
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql("ALTER TABLE organization ADD domains JSON DEFAULT '[]' NOT NULL COMMENT '(DC2Type:json)'");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE organization DROP domains');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE organization DROP domains');
+        }
+    }
+}

--- a/src/Controller/OrganizationsController.php
+++ b/src/Controller/OrganizationsController.php
@@ -71,6 +71,7 @@ class OrganizationsController extends BaseController
         }
 
         $organization = $form->getData();
+        $organization->normalizeDomains();
         $orgaRepository->save($organization, true);
 
         return $this->redirectToRoute('organizations');
@@ -122,6 +123,7 @@ class OrganizationsController extends BaseController
         }
 
         $organization = $form->getData();
+        $organization->normalizeDomains();
         $orgaRepository->save($organization, true);
 
         $this->addFlash('success', new TranslatableMessage('notifications.saved'));

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -11,6 +11,8 @@ use App\ActivityMonitor\MonitorableEntityTrait;
 use App\Repository\OrganizationRepository;
 use App\Uid\UidEntityInterface;
 use App\Uid\UidEntityTrait;
+use App\Utils;
+use App\Validator as AppAssert;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
@@ -74,6 +76,16 @@ class Organization implements MonitorableEntityInterface, UidEntityInterface
     #[ORM\OneToMany(mappedBy: 'organization', targetEntity: TeamAuthorization::class)]
     private Collection $teamAuthorizations;
 
+    /** @var string[] */
+    #[ORM\Column(options: ['default' => '[]'])]
+    #[Assert\All([
+        new AppAssert\OrganizationDomain(
+            messageDuplicated: new TranslatableMessage('organization.domains.already_used', [], 'errors'),
+            messageInvalid: new TranslatableMessage('organization.domains.invalid', [], 'errors'),
+        ),
+    ])]
+    private array $domains = [];
+
     public function __construct()
     {
         $this->name = '';
@@ -116,5 +128,55 @@ class Organization implements MonitorableEntityInterface, UidEntityInterface
     public function getTeamAuthorizations(): Collection
     {
         return $this->teamAuthorizations;
+    }
+
+    /**
+     * @return string[]
+     **/
+    public function getDomains(): array
+    {
+        return array_map(function ($domain): string {
+            if ($domain === '*') {
+                return '*';
+            } else {
+                return Utils\Url::domainToUtf8($domain);
+            }
+        }, $this->domains);
+    }
+
+    /**
+     * @param string[] $domains
+     **/
+    public function setDomains(array $domains): static
+    {
+        $this->domains = array_map(function ($domain): string {
+            if ($domain === '*') {
+                return '*';
+            } else {
+                return Utils\Url::sanitizeDomain($domain);
+            }
+        }, $domains);
+
+        return $this;
+    }
+
+    public function normalizeDomains(): static
+    {
+        $domains = $this->domains;
+
+        // Make sure the list doesn't contain empty or duplicated values.
+        $domains = array_filter($domains);
+        $domains = array_unique($domains);
+
+        // Make sure to reset the array keys. Otherwise, we could store
+        // something like `{"2": "example.com"}`. This would break the
+        // findOneByDomain / JSON_CONTAINS method.
+        // This MUST be done outside of the setDomains. Indeed, otherwise we
+        // would break the references in the form in case of errors.
+        $domains = array_values($domains);
+
+        $this->domains = $domains;
+
+        return $this;
     }
 }

--- a/src/Form/Type/OrganizationType.php
+++ b/src/Form/Type/OrganizationType.php
@@ -20,6 +20,14 @@ class OrganizationType extends AbstractType
             'empty_data' => '',
             'trim' => true,
         ]);
+        $builder->add('domains', Type\CollectionType::class, [
+            'entry_type' => Type\TextType::class,
+            'entry_options' => [
+                'trim' => true,
+            ],
+            'allow_add' => true,
+            'allow_delete' => true,
+        ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -10,6 +10,7 @@ use App\Entity\Organization;
 use App\Entity\User;
 use App\Uid\UidGeneratorInterface;
 use App\Uid\UidGeneratorTrait;
+use App\Utils;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -81,5 +82,21 @@ class OrganizationRepository extends ServiceEntityRepository implements UidGener
                 'id' => $authorizedOrgaIds,
             ]);
         }
+    }
+
+    public function findOneByDomain(string $domain): ?Organization
+    {
+        $domain = Utils\Url::sanitizeDomain($domain);
+
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT o
+            FROM App\Entity\Organization o
+            WHERE JSON_CONTAINS(o.domains, :domain) = true
+        SQL);
+        $query->setParameter('domain', '"' . $domain . '"');
+
+        return $query->getOneOrNullResult();
     }
 }

--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -99,4 +99,23 @@ class OrganizationRepository extends ServiceEntityRepository implements UidGener
 
         return $query->getOneOrNullResult();
     }
+
+    public function findOneByDomainOrDefault(string $domain): ?Organization
+    {
+        $organization = $this->findOneByDomain($domain);
+
+        if ($organization) {
+            return $organization;
+        }
+
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT o
+            FROM App\Entity\Organization o
+            WHERE JSON_CONTAINS(o.domains, '"*"') = true
+        SQL);
+
+        return $query->getOneOrNullResult();
+    }
 }

--- a/src/Utils/Url.php
+++ b/src/Utils/Url.php
@@ -24,4 +24,15 @@ class Url
 
         return $domain;
     }
+
+    public static function domainToUtf8(string $domain): string
+    {
+        $utf8Domain = idn_to_utf8($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+
+        if ($utf8Domain === false) {
+            return $domain;
+        } else {
+            return $utf8Domain;
+        }
+    }
 }

--- a/src/Validator/OrganizationDomain.php
+++ b/src/Validator/OrganizationDomain.php
@@ -1,0 +1,24 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class OrganizationDomain extends Constraint
+{
+    #[HasNamedArguments]
+    public function __construct(
+        public string $messageDuplicated,
+        public string $messageInvalid,
+        array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}

--- a/src/Validator/OrganizationDomainValidator.php
+++ b/src/Validator/OrganizationDomainValidator.php
@@ -1,0 +1,65 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2023 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Validator;
+
+use App\Entity\Organization;
+use App\Repository\OrganizationRepository;
+use App\Utils;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class OrganizationDomainValidator extends ConstraintValidator
+{
+    public function __construct(
+        private OrganizationRepository $organizationRepository,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof OrganizationDomain) {
+            throw new UnexpectedTypeException($constraint, OrganizationDomain::class);
+        }
+
+        $currentOrganization = $this->context->getObject();
+
+        if (!$currentOrganization instanceof Organization) {
+            throw new UnexpectedTypeException($currentOrganization, Organization::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $isValid = filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        $isValid = $isValid && str_contains($value, '.');
+        $isValid = $isValid || $value === '*';
+
+        $domain = Utils\Url::domainToUtf8($value);
+
+        if ($isValid === false) {
+            $this->context->buildViolation($constraint->messageInvalid)
+                ->setParameter('{{ domain }}', $domain)
+                ->addViolation();
+            return;
+        }
+
+        $existingOrganization = $this->organizationRepository->findOneByDomain($value);
+
+        if ($existingOrganization !== null && $currentOrganization->getUid() !== $existingOrganization->getUid()) {
+            $this->context->buildViolation($constraint->messageDuplicated)
+                ->setParameter('{{ domain }}', $domain)
+                ->setParameter('{{ organization }}', $existingOrganization->getName())
+                ->addViolation();
+        }
+    }
+}

--- a/templates/organizations/_form.html.twig
+++ b/templates/organizations/_form.html.twig
@@ -34,6 +34,27 @@
         />
     </div>
 
+    <div class="flow flow--small">
+        <label for="{{ field_id(form.domains) }}">
+            {{ 'organizations.domains' | trans }}
+        </label>
+
+        <p id="domains-caption" class="form__caption">
+            {{ 'organizations.domains.caption' | trans }}
+        </p>
+
+        {% for childField in form.domains %}
+            {{ form_errors(childField) }}
+        {% endfor %}
+
+        {{ include('form/_input_texts.html.twig', {
+            field: form.domains,
+            inputAttrs: {
+                'aria-describedby': 'domains-caption',
+            }
+        }, with_context = false) }}
+    </div>
+
     <div class="form__actions">
         <button class="button--primary" type="submit">
             {{ submit_label }}

--- a/tests/Utils/UrlTest.php
+++ b/tests/Utils/UrlTest.php
@@ -46,4 +46,13 @@ class UrlTest extends TestCase
 
         $this->assertEquals('xn--xample-9ua.com', $sanitizedDomain);
     }
+
+    public function testDomainToUtf8(): void
+    {
+        $domain = 'xn--xample-9ua.com';
+
+        $utf8Domain = Url::domainToUtf8($domain);
+
+        $this->assertEquals('éxample.com', $utf8Domain);
+    }
 }

--- a/translations/errors+intl-icu.en_GB.yaml
+++ b/translations/errors+intl-icu.en_GB.yaml
@@ -26,6 +26,8 @@ message_document.mimetype.rejected: 'You cannot upload this type of file, choose
 message_document.required: 'Select a file.'
 message_document.server_error: 'The file cannot be uploaded, try again later.'
 message_document.too_large: 'This file is too large, try with a smaller one.'
+organization.domains.already_used: 'The domain {domain} is already used by another organization ({organization}).'
+organization.domains.invalid: 'The domain {domain} is invalid, enter a valid domain.'
 organization.name.already_used: 'Enter a different name, an organization already has this name.'
 organization.name.max_chars: 'Enter a name of less than {limit} characters.'
 organization.name.required: 'Enter a name.'

--- a/translations/errors+intl-icu.fr_FR.yaml
+++ b/translations/errors+intl-icu.fr_FR.yaml
@@ -26,6 +26,8 @@ message_document.mimetype.rejected: 'Vous ne pouvez pas téléverser ce type de 
 message_document.required: 'Sélectionnez un fichier.'
 message_document.server_error: 'Le fichier ne peut pas être téléversé, essayez à nouveau plus tard.'
 message_document.too_large: 'Le fichier est trop gros, essayez avec un plus petit.'
+organization.domains.already_used: 'Le domaine {domain} est déjà utilisé par une autre organisation ({organization}).'
+organization.domains.invalid: 'Le domaine {domain} est invalide, saisissez un domaine valide.'
 organization.name.already_used: 'Saisissez un nom différent, une organisation porte déjà ce même nom.'
 organization.name.max_chars: 'Saisissez un nom de moins de {limit} caractères.'
 organization.name.required: 'Saisissez un nom.'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -182,6 +182,8 @@ message_documents.attachments: Attachments
 message_documents.attachments.attach: 'Attach a document'
 message_documents.remove: 'Remove attachment'
 notifications.saved: 'Your changes have been successfully saved.'
+organizations.domains: 'Linked domains'
+organizations.domains.caption: 'Users whose email address corresponds to one of these domains will be associated with this organization by default. Use the “*” character to handle all domains.'
 organizations.index.new_organization: 'New organization'
 organizations.index.none: 'No organizations'
 organizations.index.number: '{count, plural, =0 {No organizations} one {1 organization} other {# organizations}}'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -182,6 +182,8 @@ message_documents.attachments: Pièces-jointes
 message_documents.attachments.attach: 'Ajouter une pièce-jointe'
 message_documents.remove: 'Retirer la pièce-jointe'
 notifications.saved: 'Vos changements ont été sauvegardés.'
+organizations.domains: 'Domaines liés'
+organizations.domains.caption: "Les utilisateurs dont l’adresse email correspond à l’un de ces domaines seront associés à cette organisation par défaut. Utilisez le caractère «\_*\_» pour prendre en charge tous les domaines."
 organizations.index.new_organization: 'Nouvelle organisation'
 organizations.index.none: 'Aucune organisation'
 organizations.index.number: '{count, plural, =0 {Aucune organisation} one {1 organisation} other {# organisations}}'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/645

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create two organizations: associate the domain `example.com` to the first, and `*` to the other
2. Configure two email accounts (https://github.com/Probesys/bileto/blob/main/docs/developers/greenmail.md#with-thunderbird-or-any-external-mail-client): one with an existing user such as `alix@example.com` (make sure to use this domain!), and another one which doesn't exist (e.g. `dominique@example.org` → make sure the domain is different from the first one!)
3. Make sure the first user doesn't have a "default" organization, but can create tickets in the organization that handles the `example.com` domain
4. Send an email with both accounts to `support@example.com` and fetch the mailboxes
5. Verify that a new ticket is opened by `alix@example.com`
6. Verify that the email from `dominique@example.org` is blocked **because they don't have the correct permissions**. Also verify the user now exists in the database.

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
