### PR TITLE
sec: Don't use the Reply-To header to get the requester

### DIFF
--- a/docs/developers/email-collector.md
+++ b/docs/developers/email-collector.md
@@ -24,7 +24,7 @@ This is the job of the [`CreateTicketsFromMailboxEmailsHandler`](/src/MessageHan
 
 For each `MailboxEmail`:
 
-1. it gets the requester (i.e. the `Reply-To` or the `From` headers);
+1. it gets the requester (i.e. the `From` header);
 2. it gets the default organization of the requester;
 3. it detects a potential ticket to which the email might reply;
 4. if it detects a ticket, it checks that the requester can answer to it and that it is not closed;

--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -126,17 +126,6 @@ class MailboxEmail implements MonitorableEntityInterface, UidEntityInterface
         return $this->getEmail()->getFrom()->first()->mail;
     }
 
-    public function getReplyTo(): ?string
-    {
-        $address = $this->getEmail()->getReplyTo()->first();
-
-        if (!$address) {
-            return null;
-        }
-
-        return $address->mail;
-    }
-
     public function getInReplyTo(): ?string
     {
         $inReplyTo = $this->getEmail()->getInReplyTo()->first();

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -63,10 +63,7 @@ class CreateTicketsFromMailboxEmailsHandler
         $mailboxEmails = $this->mailboxEmailRepository->findAll();
 
         foreach ($mailboxEmails as $mailboxEmail) {
-            $senderEmail = $mailboxEmail->getReplyTo();
-            if (!$senderEmail) {
-                $senderEmail = $mailboxEmail->getFrom();
-            }
+            $senderEmail = $mailboxEmail->getFrom();
 
             $domain = Utils\Email::extractDomain($senderEmail);
             $domainOrganization = $this->organizationRepository->findOneByDomainOrDefault($domain);

--- a/tests/Factory/MailboxEmailFactory.php
+++ b/tests/Factory/MailboxEmailFactory.php
@@ -77,10 +77,6 @@ final class MailboxEmailFactory extends ModelFactory
                 Content-Type: text/html\r
                 TEXT;
 
-            if (isset($attributes['replyTo'])) {
-                $headers .= "\nReply-To: <{$attributes['replyTo']}>\r";
-            }
-
             if (isset($attributes['inReplyTo'])) {
                 $headers .= "\nIn-Reply-To: <{$attributes['inReplyTo']}>\r";
             }

--- a/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
+++ b/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
@@ -306,38 +306,6 @@ class CreateTicketsFromMailboxEmailsHandlerTest extends WebTestCase
         $this->assertSame($subject, $ticket->getTitle());
     }
 
-    public function testInvokeConsidersReplyToInPriority(): void
-    {
-        $container = static::getContainer();
-        /** @var MessageBusInterface */
-        $bus = $container->get(MessageBusInterface::class);
-
-        $organization = OrganizationFactory::createOne();
-        $user = UserFactory::createOne([
-            'organization' => $organization,
-        ]);
-        $this->grantOrga($user->object(), ['orga:create:tickets'], $organization->object());
-        $subject = Factory::faker()->words(3, true);
-        $body = Factory::faker()->randomHtml();
-        $mailboxEmail = MailboxEmailFactory::createOne([
-            'from' => UserFactory::createOne()->getEmail(),
-            'replyTo' => $user->getEmail(),
-        ]);
-
-        $bus->dispatch(new CreateTicketsFromMailboxEmails());
-
-        $this->assertSame(0, MailboxEmailFactory::count());
-        $this->assertSame(1, TicketFactory::count());
-        $this->assertSame(1, MessageFactory::count());
-
-        $ticket = TicketFactory::first();
-        $this->assertSame($user->getId(), $ticket->getCreatedBy()->getId());
-        $this->assertSame($user->getId(), $ticket->getRequester()->getId());
-
-        $message = MessageFactory::first();
-        $this->assertSame($user->getId(), $message->getCreatedBy()->getId());
-    }
-
     public function testInvokeCreatesATicketIfAccessIsForbiddenWhenAnswering(): void
     {
         $container = static::getContainer();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- make sure there are two users: `alix@example.com` and `charlie@example.com`
- setup the two emails accounts [in a webclient](https://github.com/Probesys/bileto/blob/a2318f6d9653c1aff2adf1e4b6c83a31933a0c51/docs/developers/greenmail.md#with-thunderbird-or-any-external-mail-client)
- send an email with `alix@example.com` to `support@example.com` BUT set "reply to" to `charlie@example.com`
- collect the mailbox
- verify a ticket is opened and the requester is `alix@example.com`

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
