### PR TITLE
fix: Fix the days diff on the ticket page

### DIFF
--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -342,7 +342,8 @@
                     {% set timelineDate = null %}
                     {% for timelineItem in timeline.sortedItems %}
                         {% if timelineDate == null or timelineDate.format('Y-m-d') != timelineItem.createdAt.format('Y-m-d') %}
-                            {% set diff = timelineDate ? timelineDate.diff(timelineItem.createdAt).d : 0 %}
+                            {# On the next line, "0 + numerical string" converts the string to an integer. #}
+                            {% set diff = timelineDate ? 0 + timelineDate.diff(timelineItem.createdAt).format('%a') : 0 %}
                             {% set timelineDate = timelineItem.createdAt %}
 
                             <div class="timeline__date">


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. create a ticket
2. wait for more than a month :)
3. add an answer
4. verify that the "days diff" is correct next to the date

Or:

1. in the seeds, change the `createdAt` of the first message to, e.g. `Time::ago(2, 'months')`
2. reset the database with `make db-reset FORCE=true`
4. verify that the "days diff" is correct next to the date

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [ ] code is manually tested
- [ ] permissions / authorizations are verified
- [ ] interface works on both mobiles and big screens
- [ ] interface works in both light and dark modes
- [ ] interface works on both Firefox and Chrome
- [ ] accessibility has been tested
- [ ] tests are up-to-date
- [ ] locales are synchronized
- [ ] copyright notices are up to date
- [ ] documentation is up to date (including migration notes)
