### PR TITLE
new: Allow to search and filter tickets by labels

### DIFF
--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -44,10 +44,12 @@ class TicketsController extends BaseController
     public function index(
         Organization $organization,
         Request $request,
+        LabelRepository $labelRepository,
         OrganizationRepository $organizationRepository,
+        UserRepository $userRepository,
         TicketSearcher $ticketSearcher,
         ActorsLister $actorsLister,
-        UserRepository $userRepository,
+        LabelSorter $labelSorter,
         TranslatorInterface $translator,
     ): Response {
         $this->denyAccessUnlessGranted('orga:see', $organization);
@@ -103,6 +105,9 @@ class TicketsController extends BaseController
             $ticketFilter = new TicketFilter();
         }
 
+        $labels = $labelRepository->findAll();
+        $labelSorter->sort($labels);
+
         return $this->render('organizations/tickets/index.html.twig', [
             'organization' => $organization,
             'ticketsPagination' => $ticketsPagination,
@@ -117,6 +122,7 @@ class TicketsController extends BaseController
             'finishedStatuses' => Ticket::getStatusesWithLabels('finished'),
             'allUsers' => $actorsLister->findByOrganization($organization),
             'agents' => $actorsLister->findByOrganization($organization, roleType: 'agent'),
+            'labels' => $labels,
             'errors' => $errors,
         ]);
     }

--- a/src/Repository/LabelRepository.php
+++ b/src/Repository/LabelRepository.php
@@ -25,4 +25,22 @@ class LabelRepository extends ServiceEntityRepository implements UidGeneratorInt
     {
         parent::__construct($registry, Label::class);
     }
+
+    /**
+     * @return Label[]
+     */
+    public function findByName(string $name): array
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT l
+            FROM App\Entity\Label l
+            WHERE LOWER(l.name) = LOWER(:name)
+        SQL);
+
+        $query->setParameter('name', $name);
+
+        return $query->getResult();
+    }
 }

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -54,6 +54,7 @@
                         finishedStatuses: finishedStatuses,
                         allUsers: allUsers,
                         agents: agents,
+                        labels: labels,
                         organization: organization,
                         from: path('organization tickets', { uid: organization.uid }),
                         error: errors.search ?? ''

--- a/templates/pages/advanced_search_syntax.html.twig
+++ b/templates/pages/advanced_search_syntax.html.twig
@@ -9,8 +9,8 @@
 {% block title %}{{ 'advanced_search_syntax.title' | trans }}{% endblock %}
 
 {% block body %}
-    <div class="wrapper wrapper--text wrapper--center flow flow--larger">
-        <div class="flow">
+    <div class="flow flow--larger">
+        <div class="wrapper wrapper--text wrapper--center flow">
             <p>
                 {{ 'advanced_search_syntax.intro1' | trans }}
             </p>
@@ -73,7 +73,7 @@
         <div class="flow flow--large">
             <h2>{{ 'advanced_search_syntax.qualifiers.title' | trans }}</h2>
 
-            <p>
+            <p class="wrapper wrapper--text">
                 {{ 'advanced_search_syntax.qualifiers.description' | trans | raw }}
             </p>
 
@@ -101,7 +101,7 @@
                     </tbody>
                 </table>
 
-                <p>
+                <p class="wrapper wrapper--text">
                     {{ 'advanced_search_syntax.qualifiers.status.values' | trans | raw }}
                 </p>
             </div>
@@ -122,12 +122,13 @@
                             <td><code>type:incident</code></td>
                             <td>{{ 'advanced_search_syntax.qualifiers.type.example1' | trans }}</td>
                         </tr>
+
+                        <tr>
+                            <td><code>type:request</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.type.example2' | trans }}</td>
+                        </tr>
                     </tbody>
                 </table>
-
-                <p>
-                    {{ 'advanced_search_syntax.qualifiers.type.values' | trans | raw }}
-                </p>
             </div>
 
             <div class="flow">

--- a/templates/pages/advanced_search_syntax.html.twig
+++ b/templates/pages/advanced_search_syntax.html.twig
@@ -245,6 +245,46 @@
                     </tbody>
                 </table>
             </div>
+
+            <div class="flow">
+                <h3>{{ 'advanced_search_syntax.qualifiers.labels.title' | trans }}</h3>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th class="col--size30">{{ 'advanced_search_syntax.example' | trans }}</th>
+                            <th>{{ 'advanced_search_syntax.description' | trans }}</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td><code>label:bug</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.labels.example1' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>label:bug label:"Tickets topic"</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.labels.example2' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>label:bug,"Tickets topic"</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.labels.example3' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>has:label</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.labels.example4' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>no:label</code></td>
+                            <td>{{ 'advanced_search_syntax.qualifiers.labels.example5' | trans }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="flow">

--- a/templates/tickets/_search_form.html.twig
+++ b/templates/tickets/_search_form.html.twig
@@ -208,6 +208,30 @@
                     </details>
                 {% endif %}
 
+                <details class="accordion" {{ ticketFilter.anyFilters(['label']) ? 'open' }}>
+                    <summary class="accordion__title">
+                        {{ 'tickets.filters.labels.title' | trans }}
+                    </summary>
+
+                    <div class="accordion__body flow">
+                        {% for label in labels %}
+                            <div>
+                                <input
+                                    type="checkbox"
+                                    id="filter-label-{{ label.uid }}"
+                                    name="filters[label][]"
+                                    value="{{ label.name }}"
+                                    {{ label.name in ticketFilter.filter('label') ? 'checked' }}
+                                />
+
+                                <label for="filter-label-{{ label.uid }}">
+                                    {{ label.name }}
+                                </label>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </details>
+
                 <details class="accordion" {{ ticketFilter.anyFilters(['priority', 'urgency', 'impact']) ? 'open' }}>
                     <summary class="accordion__title">
                         {{ 'tickets.filters.priority.title' | trans }}
@@ -413,6 +437,7 @@
             <input type="hidden" name="filters[involves][]" value="" />
             <input type="hidden" name="filters[assignee][]" value="" />
             <input type="hidden" name="filters[requester][]" value="" />
+            <input type="hidden" name="filters[label][]" value="" />
 
             <input type="hidden" name="mode" value="quick">
             <input type="hidden" name="from" value="{{ from }}">

--- a/templates/tickets/index.html.twig
+++ b/templates/tickets/index.html.twig
@@ -56,6 +56,7 @@
                         finishedStatuses: finishedStatuses,
                         allUsers: allUsers,
                         agents: agents,
+                        labels: labels,
                         organization: null,
                         from: path('tickets'),
                         error: errors.search ?? ''

--- a/tests/Controller/Tickets/FiltersControllerTest.php
+++ b/tests/Controller/Tickets/FiltersControllerTest.php
@@ -105,6 +105,24 @@ class FiltersControllerTest extends WebTestCase
         $this->assertResponseRedirects("/tickets?q={$expectedQuery}", 302);
     }
 
+    public function testPostCombineWithLabels(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->_real());
+
+        $crawler = $client->request(Request::METHOD_POST, '/tickets/filters/combine', [
+            'filters' => [
+                'label' => ['spam', 'egg'],
+            ],
+            'query' => 'label:foo label:bar',
+            'from' => '/tickets',
+        ]);
+
+        $expectedQuery = urlencode('label:spam label:egg');
+        $this->assertResponseRedirects("/tickets?q={$expectedQuery}", 302);
+    }
+
     public function testPostCombineResetsQueryIfInvalid(): void
     {
         $client = static::createClient();

--- a/tests/SearchEngine/TicketFilterTest.php
+++ b/tests/SearchEngine/TicketFilterTest.php
@@ -142,6 +142,16 @@ class TicketFilterTest extends WebTestCase
         $this->assertSame(['high'], $ticketFilter->getFilter('priority'));
     }
 
+    public function testFromQueryWithLabelConditionsReturnsFilter(): void
+    {
+        $query = Query::fromString('label:foo label:bar');
+
+        $ticketFilter = TicketFilter::fromQuery($query);
+
+        $this->assertNotNull($ticketFilter);
+        $this->assertSame(['foo', 'bar'], $ticketFilter->getFilter('label'));
+    }
+
     public function testFromQueryWithNotSupportedQualifierConditionReturnsNull(): void
     {
         $query = Query::fromString('org:#1');
@@ -369,6 +379,16 @@ class TicketFilterTest extends WebTestCase
         $textualQuery = $ticketFilter->toTextualQuery();
 
         $this->assertSame('priority:high', $textualQuery);
+    }
+
+    public function testToTextualQueryWithLabel(): void
+    {
+        $query = Query::fromString('label:foo label:"bar baz"');
+        $ticketFilter = TicketFilter::fromQuery($query);
+
+        $textualQuery = $ticketFilter->toTextualQuery();
+
+        $this->assertSame('label:foo label:"bar baz"', $textualQuery);
     }
 
     public function testSetText(): void

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -32,6 +32,12 @@ advanced_search_syntax.qualifiers.actors.example4: 'Tickets without an assigned 
 advanced_search_syntax.qualifiers.actors.example5: 'Tickets with an assigned agent'
 advanced_search_syntax.qualifiers.actors.title: Actors
 advanced_search_syntax.qualifiers.description: 'Qualifiers are special keywords (e.g. <code>status:</code>) that take a value or a comma-separated list of values. They are used to target a particular property.'
+advanced_search_syntax.qualifiers.labels.example1: 'Tickets with the label “Bug” (case insensitive)'
+advanced_search_syntax.qualifiers.labels.example2: 'Tickets with the labels “Bug” and “Tickets topic”'
+advanced_search_syntax.qualifiers.labels.example3: 'Tickets with the labels “Bug” or “Tickets topic”'
+advanced_search_syntax.qualifiers.labels.example4: 'Tickets having at least one label'
+advanced_search_syntax.qualifiers.labels.example5: 'Tickets having no labels'
+advanced_search_syntax.qualifiers.labels.title: Labels
 advanced_search_syntax.qualifiers.organization.example1: 'Tickets from organizations with “probesys” in their name'
 advanced_search_syntax.qualifiers.organization.title: Organizations
 advanced_search_syntax.qualifiers.priority.example1: 'Tickets with “low” urgency'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -44,11 +44,11 @@ advanced_search_syntax.qualifiers.solution.title: Solution
 advanced_search_syntax.qualifiers.status.example1: 'Tickets with the status “new”'
 advanced_search_syntax.qualifiers.status.example2: 'Tickets with the status “new” or “in progress”'
 advanced_search_syntax.qualifiers.status.title: Status
-advanced_search_syntax.qualifiers.status.values: 'The possible values for “status” are: <code>new</code>, <code>in_progress</code>, <code>planned</code>, <code>pending</code>, <code>resolved</code>, <code>closed</code>, as well as the shortcuts <code>open</code> (includes the first 4) and <code>finished</code> (includes the last 2).'
+advanced_search_syntax.qualifiers.status.values: 'The possible values for status are: <code>new</code>, <code>in_progress</code>, <code>planned</code>, <code>pending</code>, <code>resolved</code>, <code>closed</code>, as well as the shortcuts <code>open</code> (includes the first 4) and <code>finished</code> (includes the last 2).'
 advanced_search_syntax.qualifiers.title: 'Search by qualifiers'
 advanced_search_syntax.qualifiers.type.example1: 'Tickets of type “incident”'
+advanced_search_syntax.qualifiers.type.example2: 'Tickets of type “request”'
 advanced_search_syntax.qualifiers.type.title: Type
-advanced_search_syntax.qualifiers.type.values: 'The possible values for “type“ are: <code>incident</code> and <code>request</code>.'
 advanced_search_syntax.title: 'Quick reference for the advanced syntax'
 authorizations.new.global: Global
 authorizations.new.organization_caption: 'The authorization can be limited to a specific organization, or be applied globally.'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -355,6 +355,7 @@ tickets.filters.actors.select: 'Select an actor'
 tickets.filters.actors.title: 'Filter by actors'
 tickets.filters.actors.unselect: Unselect
 tickets.filters.assignee.no: 'Unassigned only'
+tickets.filters.labels.title: 'Filter by labels'
 tickets.filters.priority.title: 'Filter by priority'
 tickets.filters.status.title: 'Filter by status'
 tickets.filters.type.label: 'Type of tickets'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -32,6 +32,12 @@ advanced_search_syntax.qualifiers.actors.example4: 'Les tickets n’ayant pas d�
 advanced_search_syntax.qualifiers.actors.example5: 'Les tickets ayant un agent attribué'
 advanced_search_syntax.qualifiers.actors.title: Acteurs
 advanced_search_syntax.qualifiers.description: 'Les qualificateurs sont des mots-clés particuliers (ex. <code>status:</code>) qui prennent une valeur ou une liste de valeurs séparées par des virgules. Ils permettent de cibler une propriété en particulier.'
+advanced_search_syntax.qualifiers.labels.example1: "Les tickets avec l’étiquette «\_Bug\_» (insensible à la casse)"
+advanced_search_syntax.qualifiers.labels.example2: "Les tickets avec les étiquettes «\_Bug\_» et «\_Tickets topic\_»"
+advanced_search_syntax.qualifiers.labels.example3: "Les tickets avec les étiquettes «\_Bug\_» ou «\_Tickets topic\_»"
+advanced_search_syntax.qualifiers.labels.example4: 'Les tickets ayant au moins une étiquette'
+advanced_search_syntax.qualifiers.labels.example5: 'Les tickets n’ayant aucune étiquette'
+advanced_search_syntax.qualifiers.labels.title: Étiquettes
 advanced_search_syntax.qualifiers.organization.example1: "Les tickets des organisations dont le nom contient «\_probesys\_»"
 advanced_search_syntax.qualifiers.organization.title: Organisations
 advanced_search_syntax.qualifiers.priority.example1: "Les tickets d’urgence «\_basse\_»"

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -355,6 +355,7 @@ tickets.filters.actors.select: 'Sélectionner un acteur'
 tickets.filters.actors.title: 'Filtrer par acteurs'
 tickets.filters.actors.unselect: Désélectionner
 tickets.filters.assignee.no: 'Non attribués seulement'
+tickets.filters.labels.title: 'Filtrer par étiquettes'
 tickets.filters.priority.title: 'Filtrer par priorité'
 tickets.filters.status.title: 'Filtrer par statut'
 tickets.filters.type.label: 'Type des tickets'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -44,11 +44,11 @@ advanced_search_syntax.qualifiers.solution.title: Solution
 advanced_search_syntax.qualifiers.status.example1: "Les tickets avec le statut «\_nouveau\_»"
 advanced_search_syntax.qualifiers.status.example2: "Les tickets avec les statuts «\_nouveau\_» ou «\_en cours\_»"
 advanced_search_syntax.qualifiers.status.title: Statut
-advanced_search_syntax.qualifiers.status.values: "Les valeurs possibles pour «\_<code>status</code>\_» sont\_: <code>new</code>, <code>in_progress</code>, <code>planned</code>, <code>pending</code>, <code>resolved</code>, <code>closed</code>, ainsi que les raccourcis <code>open</code> (incluant les 4 premiers) et <code>finished</code> (incluant les 2 derniers)."
+advanced_search_syntax.qualifiers.status.values: "Les valeurs de statut possibles sont\_: <code>new</code>, <code>in_progress</code>, <code>planned</code>, <code>pending</code>, <code>resolved</code>, <code>closed</code>, ainsi que les raccourcis <code>open</code> (incluant les 4 premiers) et <code>finished</code> (incluant les 2 derniers)."
 advanced_search_syntax.qualifiers.title: 'Rechercher par qualificateurs'
 advanced_search_syntax.qualifiers.type.example1: "Les tickets de type «\_incident\_»"
+advanced_search_syntax.qualifiers.type.example2: "Les tickets de type «\_requête\_»"
 advanced_search_syntax.qualifiers.type.title: Type
-advanced_search_syntax.qualifiers.type.values: "Les valeurs possibles pour «\_type\_» sont\_: <code>incident</code> et <code>request</code>."
 advanced_search_syntax.title: 'Aide-mémoire de la syntaxe avancée'
 authorizations.new.global: Global
 authorizations.new.organization_caption: 'L’autorisation peut être limitée à une organisation spécifique, ou appliquée globalement.'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/283

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Make sure your user has the permission to create labels and update tickets' labels
2. Create at least 2 labels in the admin
3. Attach a ticket to the first label, another one to the other, and a last ticket to both labels
4. In the tickets list, filter only by the first label → verify that the first and third tickets appear
4. Filter only by the second label → verify that the second and third tickets appear
4. Filter by both labels → verify that only the third ticket appears

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
