### PR TITLE
fix: Fix search with "NOT assignee" for unassigned tickets

### DIFF
--- a/src/SearchEngine/QueryBuilder/TicketQueryBuilder.php
+++ b/src/SearchEngine/QueryBuilder/TicketQueryBuilder.php
@@ -151,7 +151,8 @@ class TicketQueryBuilder
             return $this->buildExpr('t.status', $value, $condition->not());
         } elseif ($qualifier === 'assignee' || $qualifier === 'requester') {
             $value = $this->processActorQualifier($value);
-            return $this->buildExpr('t.' . $qualifier, $value, $condition->not());
+            $field = "COALESCE(IDENTITY(t.{$qualifier}), 0)";
+            return $this->buildExpr($field, $value, $condition->not());
         } elseif ($qualifier === 'involves') {
             $value = $this->processActorQualifier($value);
 

--- a/tests/SearchEngine/QueryBuilder/TicketQueryBuilderTest.php
+++ b/tests/SearchEngine/QueryBuilder/TicketQueryBuilderTest.php
@@ -236,7 +236,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.assignee = :q0p0
+            COALESCE(IDENTITY(t.assignee), 0) = :q0p0
             SQL, $dql);
         $this->assertSame($alix->getId(), $parameters['q0p0']);
     }
@@ -251,7 +251,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.assignee = :q0p0
+            COALESCE(IDENTITY(t.assignee), 0) = :q0p0
             SQL, $dql);
         $this->assertSame($alix->getId(), $parameters['q0p0']);
     }
@@ -263,7 +263,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.assignee = :q0p0
+            COALESCE(IDENTITY(t.assignee), 0) = :q0p0
             SQL, $dql);
         $this->assertSame($this->currentUser->getId(), $parameters['q0p0']);
     }
@@ -278,7 +278,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.assignee IN (:q0p0)
+            COALESCE(IDENTITY(t.assignee), 0) IN (:q0p0)
             SQL, $dql);
         $this->assertSame(
             [$alix->getId(), $this->currentUser->getId()],
@@ -293,7 +293,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.assignee = :q0p0
+            COALESCE(IDENTITY(t.assignee), 0) = :q0p0
             SQL, $dql);
         $this->assertSame(-1, $parameters['q0p0']);
     }
@@ -308,7 +308,7 @@ class TicketQueryBuilderTest extends WebTestCase
         list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
 
         $this->assertSame(<<<SQL
-            t.requester = :q0p0
+            COALESCE(IDENTITY(t.requester), 0) = :q0p0
             SQL, $dql);
         $this->assertSame($alix->getId(), $parameters['q0p0']);
     }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/pull/689

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- Create three tickets: one assigned to your user, one unassigned, one assigned to another user
- Search for `assignee:@me`
- Verify that you see only your ticket
- Search for `NOT assignee:@me`
- Verify that you see the others tickets

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
