### PR TITLE
imp: Allow to import teams

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 
 - [ ] code is manually tested
 - [ ] permissions / authorizations are verified
+- [ ] data can be imported correctly
 - [ ] interface works on both mobiles and big screens
 - [ ] interface works in both light and dark modes
 - [ ] interface works on both Firefox and Chrome

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,12 @@ Bileto is based on a custom system of roles.
 This system is explained in the document [“Roles & permissions”](/docs/developers/roles.md).
 This item reminds you to put the required actions behind an authorization.
 
+#### “Data can be imported correctly”
+
+When new entities or fields are created, we need to consider making this data importable by [the `DataImporter` service](/src/Service/DataImporter/DataImporter.php).
+However, not all data needs to be imported.
+If fields are changed or removed, the service needs to be adjusted as well.
+
 #### “Interface works on both mobile and big screen”
 
 We want Bileto to work on desktop and mobiles.

--- a/docs/developers/import-data.md
+++ b/docs/developers/import-data.md
@@ -55,7 +55,7 @@ The data is stored in a ZIP archive. It contains several files:
   - name: string (unique, not empty, max 50 chars)
   - description: string (not empty, max 255 chars)
   - type: string (must be `super`, `admin`, `agent`, or `user`, `super` must be unique)
-  - permissions: array of string, optional (see `Role::PERMISSIONS` for the list of valid strings)
+  - permissions: array of strings, optional (see `Role::PERMISSIONS` for the list of valid strings)
 - `users.json` an array of users defined as:
   - id: string (unique)
   - email: string (unique, not empty, valid email)
@@ -64,6 +64,12 @@ The data is stored in a ZIP archive. It contains several files:
   - ldapIdentifier: string or null, optional
   - organizationId: string or null, optional (reference to an organization)
   - authorizations: array of, optional:
+    - roleId: string (reference to a role)
+    - organizationId: string or null (reference to an organization)
+- `teams.json` an array of teams defined as:
+  - id: string (unique)
+  - name: string (unique, not empty, max 50 chars)
+  - teamAuthorizations: array of, optional:
     - roleId: string (reference to a role)
     - organizationId: string or null (reference to an organization)
 - `contracts.json` an array of contracts defined as:
@@ -98,8 +104,8 @@ It also contains a `tickets/` folder where each file corresponds to a ticket. Fo
 - assigneeId: string or null, optional (reference to a user)
 - organizationId: string (reference to an organization)
 - solutionId: string or null, optional (reference to a message, included in ticket.messages)
-- contractIds: array of string, optional (references to contracts)
-- labelIds: array of string, optional (references to labels)
+- contractIds: array of strings, optional (references to contracts)
+- labelIds: array of strings, optional (references to labels)
 - timeSpents: array of, optional:
   - createdAt: datetime
   - createdById: string (reference to a user)
@@ -129,7 +135,7 @@ A file (or folder) can be missing. In this case, it is considered that there is 
 
 When importing the data, some elements may already exist in the database (e.g. users have been imported from LDAP, or the command failed the first time after importing part of the data).
 
-We can easily detect existing data for organizations, roles, users and labels. Indeed, these entities require the uniqueness of a field (name or email). Thus, if we detect that a corresponding entity already exists (using the unique field), we can load the entity from the database to reuse it.
+We can easily detect existing data for organizations, roles, users, teams and labels. Indeed, these entities require the uniqueness of a field (name or email). Thus, if we detect that a corresponding entity already exists (using the unique field), we can load the entity from the database to reuse it.
 
 Contracts and tickets are harder to handle as there is no unique field that could help us to detect existing data. Custom logic can be used though:
 

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -64,7 +64,11 @@ class Team implements MonitorableEntityInterface, UidEntityInterface
     private Collection $agents;
 
     /** @var Collection<int, TeamAuthorization> */
-    #[ORM\OneToMany(mappedBy: 'team', targetEntity: TeamAuthorization::class)]
+    #[ORM\OneToMany(
+        mappedBy: 'team',
+        targetEntity: TeamAuthorization::class,
+        cascade: ['persist'],
+    )]
     private Collection $teamAuthorizations;
 
     public function __construct()
@@ -131,5 +135,15 @@ class Team implements MonitorableEntityInterface, UidEntityInterface
     public function getTeamAuthorizations(): Collection
     {
         return $this->teamAuthorizations;
+    }
+
+    public function addTeamAuthorization(TeamAuthorization $teamAuthorization): static
+    {
+        if (!$this->teamAuthorizations->contains($teamAuthorization)) {
+            $this->teamAuthorizations->add($teamAuthorization);
+            $teamAuthorization->setTeam($this);
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create an archive to import following the spec and containing a team
2. Call `console app:data:import data.zip`
3. Verify that the team is imported

Note that teams' agents cannot be imported yet. This is because we would need to associate the teamAuthorization to users' authorizations. That's too complicated to handle for now. The actual solution is to let the admins add the agents manually in the teams at the end of the import.

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
