### PR TITLE
dev: Fix some PHPUnit Testdox warnings

### DIFF
--- a/tests/Service/DataImporter/DataImporterTest.php
+++ b/tests/Service/DataImporter/DataImporterTest.php
@@ -1334,8 +1334,7 @@ class DataImporterTest extends WebTestCase
                 ],
             ],
         ];
-        $documentsPath = sys_get_temp_dir() . '/documents';
-        @mkdir($documentsPath);
+        $documentsPath = $this->createDocumentsFolder();
         $content = 'My bug';
         $hash = hash('sha256', $content);
         file_put_contents($documentsPath . '/bug.txt', $content);
@@ -2058,9 +2057,11 @@ class DataImporterTest extends WebTestCase
                 ],
             ],
         ];
-        $documentsPath = sys_get_temp_dir() . '/documents';
-        @mkdir($documentsPath);
-        @unlink($documentsPath . '/bug.txt');
+        $documentsPath = $this->createDocumentsFolder();
+        $filepath = "{$documentsPath}/bug.txt";
+        if (file_exists($filepath)) {
+            unlink($filepath);
+        }
 
         $this->processGenerator($this->dataImporter->import(
             organizations: $organizations,
@@ -2071,5 +2072,16 @@ class DataImporterTest extends WebTestCase
 
         $this->assertSame(0, MessageFactory::count());
         $this->assertSame(0, MessageDocumentFactory::count());
+    }
+
+    private function createDocumentsFolder(): string
+    {
+        $documentsPath = sys_get_temp_dir() . '/documents';
+
+        if (!is_dir($documentsPath)) {
+            mkdir($documentsPath);
+        }
+
+        return $documentsPath;
     }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make test FILE=tests/Service/DataImporter/DataImporterTest.php`
- verify that Testdox doesn't show any warning

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
