### PR TITLE
imp: Allow to set default organization' observers

### DIFF
--- a/migrations/Version20240814075419AddObserversToOrganization.php
+++ b/migrations/Version20240814075419AddObserversToOrganization.php
@@ -1,0 +1,53 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240814075419AddObserversToOrganization extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the observers relation to the organization table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // phpcs:disable Generic.Files.LineLength
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('CREATE TABLE organization_user (organization_id INT NOT NULL, user_id INT NOT NULL, PRIMARY KEY(organization_id, user_id))');
+            $this->addSql('CREATE INDEX IDX_B49AE8D432C8A3DE ON organization_user (organization_id)');
+            $this->addSql('CREATE INDEX IDX_B49AE8D4A76ED395 ON organization_user (user_id)');
+            $this->addSql('ALTER TABLE organization_user ADD CONSTRAINT FK_B49AE8D432C8A3DE FOREIGN KEY (organization_id) REFERENCES organization (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+            $this->addSql('ALTER TABLE organization_user ADD CONSTRAINT FK_B49AE8D4A76ED395 FOREIGN KEY (user_id) REFERENCES "users" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('CREATE TABLE organization_user (organization_id INT NOT NULL, user_id INT NOT NULL, INDEX IDX_B49AE8D432C8A3DE (organization_id), INDEX IDX_B49AE8D4A76ED395 (user_id), PRIMARY KEY(organization_id, user_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+            $this->addSql('ALTER TABLE organization_user ADD CONSTRAINT FK_B49AE8D432C8A3DE FOREIGN KEY (organization_id) REFERENCES organization (id) ON DELETE CASCADE');
+            $this->addSql('ALTER TABLE organization_user ADD CONSTRAINT FK_B49AE8D4A76ED395 FOREIGN KEY (user_id) REFERENCES `users` (id) ON DELETE CASCADE');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE organization_user DROP CONSTRAINT FK_B49AE8D432C8A3DE');
+            $this->addSql('ALTER TABLE organization_user DROP CONSTRAINT FK_B49AE8D4A76ED395');
+            $this->addSql('DROP TABLE organization_user');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE organization_user DROP FOREIGN KEY FK_B49AE8D432C8A3DE');
+            $this->addSql('ALTER TABLE organization_user DROP FOREIGN KEY FK_B49AE8D4A76ED395');
+            $this->addSql('DROP TABLE organization_user');
+        }
+    }
+}

--- a/src/Controller/Organizations/ObserversController.php
+++ b/src/Controller/Organizations/ObserversController.php
@@ -1,0 +1,66 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Controller\Organizations;
+
+use App\Controller\BaseController;
+use App\Entity;
+use App\Repository;
+use App\Security;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ObserversController extends BaseController
+{
+    #[Route(
+        '/organizations/{uid:organization}/observers/{uidUser:user}/switch',
+        name: 'switch organization observer',
+        methods: ['POST'],
+    )]
+    public function switch(
+        Entity\Organization $organization,
+        #[MapEntity(mapping: ['user' => 'uid'])]
+        Entity\User $user,
+        Request $request,
+        Repository\OrganizationRepository $organizationRepository,
+        Security\Authorizer $authorizer,
+        TranslatorInterface $translator,
+    ): Response {
+        $this->denyAccessUnlessGranted('orga:see:users', $organization);
+        $this->denyAccessUnlessGranted('orga:update:tickets:actors', $organization);
+
+        $csrfToken = $request->request->getString('_csrf_token');
+
+        if (!$this->isCsrfTokenValid('switch organization observer', $csrfToken)) {
+            $this->addFlash('error', $translator->trans('csrf.invalid', [], 'errors'));
+            return $this->redirectToRoute('organization users', [
+                'uid' => $organization->getUid(),
+            ]);
+        }
+
+        if (!$authorizer->isGrantedToUser($user, 'orga:see', $organization)) {
+            $this->addFlash('error', $translator->trans('organization.observers.not_authorized', [], 'errors'));
+            return $this->redirectToRoute('organization users', [
+                'uid' => $organization->getUid(),
+            ]);
+        }
+
+        if ($organization->hasObserver($user)) {
+            $organization->removeObserver($user);
+        } else {
+            $organization->addObserver($user);
+        }
+
+        $organizationRepository->save($organization, true);
+
+        return $this->redirectToRoute('organization users', [
+            'uid' => $organization->getUid(),
+        ]);
+    }
+}

--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -316,6 +316,10 @@ class TicketsController extends BaseController
         $ticket->setTeam($team);
         $ticket->setLabels($labels);
 
+        foreach ($organization->getObservers() as $observer) {
+            $ticket->addObserver($observer);
+        }
+
         $errors = $validator->validate($ticket);
         if (count($errors) > 0) {
             return $this->renderBadRequest('organizations/tickets/new.html.twig', [

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -84,12 +84,17 @@ class Organization implements MonitorableEntityInterface, UidEntityInterface
     ])]
     private array $domains = [];
 
+    /** @var Collection<int, User> */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    private Collection $observers;
+
     public function __construct()
     {
         $this->name = '';
         $this->tickets = new ArrayCollection();
         $this->authorizations = new ArrayCollection();
         $this->teamAuthorizations = new ArrayCollection();
+        $this->observers = new ArrayCollection();
     }
 
     public function getName(): ?string
@@ -174,6 +179,35 @@ class Organization implements MonitorableEntityInterface, UidEntityInterface
         $domains = array_values($domains);
 
         $this->domains = $domains;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function getObservers(): Collection
+    {
+        return $this->observers;
+    }
+
+    public function hasObserver(User $observer): bool
+    {
+        return $this->observers->contains($observer);
+    }
+
+    public function addObserver(User $observer): static
+    {
+        if (!$this->observers->contains($observer)) {
+            $this->observers->add($observer);
+        }
+
+        return $this;
+    }
+
+    public function removeObserver(User $observer): static
+    {
+        $this->observers->removeElement($observer);
 
         return $this;
     }

--- a/templates/organizations/users/index.html.twig
+++ b/templates/organizations/users/index.html.twig
@@ -51,7 +51,7 @@
 
                     {% for user in users %}
                         <li class="cols cols--center flow flow--small" data-test="user-item">
-                            <span class="col--extend flow flow--small">
+                            <div class="col--extend flow flow--small">
                                 <div class="list__item-title">
                                     {% if canManageUsers %}
                                         <a href="{{ path('user', { uid: user.uid }) }}">
@@ -73,7 +73,31 @@
                                 <div class="text--small text--wrap">
                                     {{ user.email }}
                                 </div>
-                            </span>
+                            </div>
+
+                            {% if is_granted('orga:update:tickets:actors', organization) %}
+                                <form
+                                    method="POST"
+                                    action="{{ path('switch organization observer', { uid: organization.uid, uidUser: user.uid }) }}"
+                                    data-turbo-preserve-scroll
+                                >
+                                    {% if organization.hasObserver(user) %}
+                                        <button type="submit">
+                                            {{ 'organizations.observers.remove_user' | trans }}
+                                        </button>
+                                    {% else %}
+                                        <button
+                                            type="submit"
+                                            class="button--discreet"
+                                            data-turbo-confirm="{{ "organizations.observers.confirm_add_user" | trans }}"
+                                        >
+                                            {{ 'organizations.observers.add_user' | trans }}
+                                        </button>
+                                    {% endif %}
+
+                                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('switch organization observer') }}">
+                                </form>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>

--- a/tests/Controller/Organizations/ObserversControllerTest.php
+++ b/tests/Controller/Organizations/ObserversControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Controller\Organizations;
+
+use App\Entity;
+use App\Tests;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class ObserversControllerTest extends WebTestCase
+{
+    use Tests\AuthorizationHelper;
+    use Tests\SessionHelper;
+    use Factories;
+    use ResetDatabase;
+
+    public function testPostSwitchAddsObserverToOrganization(): void
+    {
+        $client = static::createClient();
+        list(
+            $user,
+            $observer,
+        ) = Tests\Factory\UserFactory::createMany(2);
+        $client->loginUser($user->_real());
+        $organization = Tests\Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), [
+            'orga:update:tickets:actors',
+            'orga:see:users',
+        ], $organization->_real());
+        $this->grantOrga($observer->_real(), ['orga:see'], $organization->_real());
+
+        $client->request(
+            Request::METHOD_POST,
+            "/organizations/{$organization->getUid()}/observers/{$observer->getUid()}/switch",
+            [
+                '_csrf_token' => $this->generateCsrfToken($client, 'switch organization observer'),
+            ],
+        );
+
+        $this->assertResponseRedirects("/organizations/{$organization->getUid()}/users", 302);
+        $organization->_refresh();
+        $orgaObservers = $organization->getObservers();
+        $this->assertSame(1, count($orgaObservers));
+        $this->assertSame($observer->getUid(), $orgaObservers[0]->getUid());
+    }
+
+    public function testPostSwitchRemoveObserverFromOrganization(): void
+    {
+        $client = static::createClient();
+        list(
+            $user,
+            $observer,
+        ) = Tests\Factory\UserFactory::createMany(2);
+        $client->loginUser($user->_real());
+        $organization = Tests\Factory\OrganizationFactory::createOne([
+            'observers' => [$observer],
+        ]);
+        $this->grantOrga($user->_real(), [
+            'orga:update:tickets:actors',
+            'orga:see:users',
+        ], $organization->_real());
+        $this->grantOrga($observer->_real(), ['orga:see'], $organization->_real());
+
+        $client->request(
+            Request::METHOD_POST,
+            "/organizations/{$organization->getUid()}/observers/{$observer->getUid()}/switch",
+            [
+                '_csrf_token' => $this->generateCsrfToken($client, 'switch organization observer'),
+            ],
+        );
+
+        $this->assertResponseRedirects("/organizations/{$organization->getUid()}/users", 302);
+        $organization->_refresh();
+        $orgaObservers = $organization->getObservers();
+        $this->assertSame(0, count($orgaObservers));
+    }
+
+    public function testPostSwitchFailsIfCsrfTokenIsInvalid(): void
+    {
+        $client = static::createClient();
+        list(
+            $user,
+            $observer,
+        ) = Tests\Factory\UserFactory::createMany(2);
+        $client->loginUser($user->_real());
+        $organization = Tests\Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), [
+            'orga:update:tickets:actors',
+            'orga:see:users',
+        ], $organization->_real());
+        $this->grantOrga($observer->_real(), ['orga:see'], $organization->_real());
+
+        $client->request(
+            Request::METHOD_POST,
+            "/organizations/{$organization->getUid()}/observers/{$observer->getUid()}/switch",
+            [
+                '_csrf_token' => 'not a token',
+            ],
+        );
+
+        $this->assertResponseRedirects("/organizations/{$organization->getUid()}/users", 302);
+        $client->followRedirect();
+        $this->assertSelectorTextContains('#notifications', 'The security token is invalid');
+        $organization->_refresh();
+        $orgaObservers = $organization->getObservers();
+        $this->assertSame(0, count($orgaObservers));
+    }
+
+    public function testPostSwitchFailsIfUserCannotAccessOrganization(): void
+    {
+        $client = static::createClient();
+        list(
+            $user,
+            $observer,
+        ) = Tests\Factory\UserFactory::createMany(2);
+        $client->loginUser($user->_real());
+        $organization = Tests\Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), [
+            'orga:update:tickets:actors',
+            'orga:see:users',
+        ], $organization->_real());
+
+        $client->request(
+            Request::METHOD_POST,
+            "/organizations/{$organization->getUid()}/observers/{$observer->getUid()}/switch",
+            [
+                '_csrf_token' => $this->generateCsrfToken($client, 'switch organization observer'),
+            ],
+        );
+
+        $this->assertResponseRedirects("/organizations/{$organization->getUid()}/users", 302);
+        $client->followRedirect();
+        $this->assertSelectorTextContains('#notifications', 'The user is not authorized to access this organization');
+        $organization->_refresh();
+        $orgaObservers = $organization->getObservers();
+        $this->assertSame(0, count($orgaObservers));
+    }
+
+    public function testPostSwitchFailsIfAccessIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        list(
+            $user,
+            $observer,
+        ) = Tests\Factory\UserFactory::createMany(2);
+        $client->loginUser($user->_real());
+        $organization = Tests\Factory\OrganizationFactory::createOne();
+        $this->grantOrga($observer->_real(), ['orga:see'], $organization->_real());
+
+        $client->catchExceptions(false);
+        $client->request(
+            Request::METHOD_POST,
+            "/organizations/{$organization->getUid()}/observers/{$observer->getUid()}/switch",
+            [
+                '_csrf_token' => $this->generateCsrfToken($client, 'switch organization observer'),
+            ],
+        );
+    }
+}

--- a/translations/errors+intl-icu.en_GB.yaml
+++ b/translations/errors+intl-icu.en_GB.yaml
@@ -36,6 +36,7 @@ organization.domains.invalid: 'The domain {domain} is invalid, enter a valid dom
 organization.name.already_used: 'Enter a different name, an organization already has this name.'
 organization.name.max_chars: 'Enter a name of less than {limit} characters.'
 organization.name.required: 'Enter a name.'
+organization.observers.not_authorized: 'The user is not authorized to access this organization.'
 role.description.max_chars: 'Enter a description of less than {limit} characters.'
 role.description.required: 'Enter a description.'
 role.name.already_used: 'Enter a different name, a role already has this name.'

--- a/translations/errors+intl-icu.fr_FR.yaml
+++ b/translations/errors+intl-icu.fr_FR.yaml
@@ -36,6 +36,7 @@ organization.domains.invalid: 'Le domaine {domain} est invalide, saisissez un do
 organization.name.already_used: 'Saisissez un nom différent, une organisation porte déjà ce même nom.'
 organization.name.max_chars: 'Saisissez un nom de moins de {limit} caractères.'
 organization.name.required: 'Saisissez un nom.'
+organization.observers.not_authorized: 'L’utilisateur n’est pas autorisé à accéder à cette organisation.'
 role.description.max_chars: 'Saisissez une description de moins de {limit} caractères.'
 role.description.required: 'Saisissez une description.'
 role.name.already_used: 'Saisissez un nom différent, un rôle porte déjà ce même nom.'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -221,6 +221,9 @@ organizations.index.title: Organizations
 organizations.name: Name
 organizations.new.submit: 'Create the organization'
 organizations.new.title: 'New organization'
+organizations.observers.add_user: 'Add to observers'
+organizations.observers.confirm_add_user: 'By adding this user to the organization’s observers, you give him access to all future tickets opened in the organization. Can you confirm?'
+organizations.observers.remove_user: 'Remove from observers'
 organizations.settings.deletion.confirm: 'Are you sure that you want to delete this organization?'
 organizations.settings.deletion.going_delete: 'You’re going to delete the organization “{organization}”. This will also delete the associated tickets and contracts.'
 organizations.settings.deletion.submit: 'Delete the organization'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -221,6 +221,9 @@ organizations.index.title: Organisations
 organizations.name: Nom
 organizations.new.submit: 'Créer l’organisation'
 organizations.new.title: 'Nouvelle organisation'
+organizations.observers.add_user: 'Ajouter aux observateurs'
+organizations.observers.confirm_add_user: "En ajoutant cet utilisateur aux observateurs de l’organisation, vous lui permettez d’avoir accès à tous les futurs tickets ouverts dans celle-ci. Confirmez-vous\_?"
+organizations.observers.remove_user: 'Retirer des observateurs'
 organizations.settings.deletion.confirm: "Êtes-vous sûr de vouloir supprimer cette organisation\_?"
 organizations.settings.deletion.going_delete: "Vous êtes sur le point de supprimer l’organisation «\_{organization}\_». Cela supprimera également les tickets et contrats associés."
 organizations.settings.deletion.submit: 'Supprimer l’organisation'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/39

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- In an organization, go to the list of users
- Add a user as an observer
- Create a ticket
- Verify that the user is an observer of the ticket

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
