### PR TITLE
fix: Set ticket's default observers when opened by email

### DIFF
--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -136,6 +136,10 @@ class CreateTicketsFromMailboxEmailsHandler
                 $ticket->setOrganization($requesterOrganization);
                 $ticket->setRequester($requester);
 
+                foreach ($requesterOrganization->getObservers() as $observer) {
+                    $ticket->addObserver($observer);
+                }
+
                 $this->ticketRepository->save($ticket, true);
                 $isNewTicket = true;
             }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/39
https://github.com/Probesys/bileto/pull/702

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- In an organization, go to the list of users
- Add a user as an observer
- Create a ticket by email with a user in the same organization as the observer
- Verify that the observer is set on the ticket

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
