### PR TITLE
tec: Allow to change the default locale globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog of Bileto
 
+## unreleased
+
+### Migration notes
+
+You can now change the default locale globally by setting the `APP_DEFAULT_LOCALE` in your env file.
+
 ## 2024-07-05 - 0.9.0-beta
 
 This is our first beta version! 🥳

--- a/env.sample
+++ b/env.sample
@@ -16,6 +16,12 @@ APP_SECRET=change-me
 # non-HTTP contexts (i.e. from the command line).
 APP_BASE_URL=https://example.org
 
+# The default locale to use when creating a user and that no locale is
+# specified. This is useful especially when synchronizing with a LDAP server
+# or when no locale can be specified.
+# Must be either "en_GB" (default) or "fr_FR".
+# APP_DEFAULT_LOCALE=fr_FR
+
 # The path to the upload directory.
 # Default is uploads/ in the root directory.
 # APP_UPLOADS_DIRECTORY=/path/to/uploads

--- a/src/Command/SeedsCommand.php
+++ b/src/Command/SeedsCommand.php
@@ -6,17 +6,11 @@
 
 namespace App\Command;
 
-use App\Entity\Role;
-use App\Repository\AuthorizationRepository;
-use App\Repository\MailboxRepository;
-use App\Repository\MessageRepository;
-use App\Repository\OrganizationRepository;
-use App\Repository\RoleRepository;
-use App\Repository\TicketRepository;
-use App\Repository\UserRepository;
-use App\Security\Encryptor;
-use App\Utils\Random;
-use App\Utils\Time;
+use App\Entity;
+use App\Repository;
+use App\Security;
+use App\Service;
+use App\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -34,14 +28,15 @@ class SeedsCommand extends Command
     public function __construct(
         private string $environment,
         private EntityManagerInterface $entityManager,
-        private AuthorizationRepository $authorizationRepository,
-        private MailboxRepository $mailboxRepository,
-        private MessageRepository $messageRepository,
-        private OrganizationRepository $orgaRepository,
-        private RoleRepository $roleRepository,
-        private TicketRepository $ticketRepository,
-        private UserRepository $userRepository,
-        private Encryptor $encryptor,
+        private Repository\AuthorizationRepository $authorizationRepository,
+        private Repository\MailboxRepository $mailboxRepository,
+        private Repository\MessageRepository $messageRepository,
+        private Repository\OrganizationRepository $orgaRepository,
+        private Repository\RoleRepository $roleRepository,
+        private Repository\TicketRepository $ticketRepository,
+        private Repository\UserRepository $userRepository,
+        private Security\Encryptor $encryptor,
+        private Service\Locales $locales,
         private UserPasswordHasherInterface $passwordHasher,
     ) {
         parent::__construct();
@@ -59,7 +54,7 @@ class SeedsCommand extends Command
         if ($this->environment === 'dev') {
             // In dev, give all "agent" permissions to technicians so it's
             // easier to work with.
-            $techPermissions = Role::PERMISSIONS['agent'];
+            $techPermissions = Entity\Role::PERMISSIONS['agent'];
         } else {
             $techPermissions = [
                 'orga:create:tickets',
@@ -147,6 +142,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Alix Hambourg',
                 'organization' => $orgaProbesys,
+                'locale' => $this->locales->getDefaultLocale(),
             ]);
 
             $userBenedict = $this->userRepository->findOneOrCreateBy([
@@ -154,6 +150,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Benedict Aphone',
                 'organization' => $orgaProbesys,
+                'locale' => $this->locales->getDefaultLocale(),
             ]);
 
             $userCharlie = $this->userRepository->findOneOrCreateBy([
@@ -161,6 +158,7 @@ class SeedsCommand extends Command
             ], [
                 'name' => 'Charlie Gature',
                 'organization' => $orgaFriendlyCoop,
+                'locale' => $this->locales->getDefaultLocale(),
                 'ldapIdentifier' => 'charlie',
             ]);
 
@@ -226,7 +224,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => false,
                 'ticket' => $ticketEmails,
-                'createdAt' => Time::ago(1, 'day'),
+                'createdAt' => Utils\Time::ago(1, 'day'),
                 'createdBy' => $userCharlie,
                 'via' => 'webapp',
             ]);
@@ -237,7 +235,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => true,
                 'ticket' => $ticketEmails,
-                'createdAt' => Time::ago(10, 'hours'),
+                'createdAt' => Utils\Time::ago(10, 'hours'),
                 'createdBy' => $userAlix,
                 'via' => 'webapp',
             ]);
@@ -248,7 +246,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => false,
                 'ticket' => $ticketEmails,
-                'createdAt' => Time::ago(9, 'hours'),
+                'createdAt' => Utils\Time::ago(9, 'hours'),
                 'createdBy' => $userAlix,
                 'via' => 'webapp',
             ]);
@@ -273,7 +271,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => false,
                 'ticket' => $ticketUpdate,
-                'createdAt' => Time::ago(5, 'days'),
+                'createdAt' => Utils\Time::ago(5, 'days'),
                 'createdBy' => $userCharlie,
                 'via' => 'webapp',
             ]);
@@ -284,7 +282,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => false,
                 'ticket' => $ticketUpdate,
-                'createdAt' => Time::now(),
+                'createdAt' => Utils\Time::now(),
                 'createdBy' => $userAlix,
                 'via' => 'webapp',
             ]);
@@ -311,7 +309,7 @@ class SeedsCommand extends Command
                 HTML,
                 'isConfidential' => false,
                 'ticket' => $ticketFilter,
-                'createdAt' => Time::ago(42, 'days'),
+                'createdAt' => Utils\Time::ago(42, 'days'),
                 'createdBy' => $userBenedict,
                 'via' => 'webapp',
             ]);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -6,7 +6,7 @@
 
 namespace App\Controller;
 
-use App\Utils\Locales;
+use App\Service;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -28,7 +28,7 @@ class LoginController extends BaseController
 
         return $this->render('login/new.html.twig', [
             'last_identifier' => $lastIdentifier,
-            'availableLanguages' => Locales::getSupportedLanguages(),
+            'availableLanguages' => Service\Locales::SUPPORTED_LOCALES,
             'error' => $error,
         ]);
     }

--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -10,8 +10,8 @@ use App\Entity\Ticket;
 use App\Repository\AuthorizationRepository;
 use App\Repository\OrganizationRepository;
 use App\SearchEngine\TicketSearcher;
+use App\Service;
 use App\Service\Sorter\OrganizationSorter;
-use App\Utils\Locales;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -47,7 +47,7 @@ class PagesController extends BaseController
 
         return $this->render('pages/about.html.twig', [
             'version' => $version,
-            'availableLanguages' => Locales::getSupportedLanguages(),
+            'availableLanguages' => Service\Locales::SUPPORTED_LOCALES,
         ]);
     }
 

--- a/src/Controller/PreferencesController.php
+++ b/src/Controller/PreferencesController.php
@@ -7,8 +7,8 @@
 namespace App\Controller;
 
 use App\Repository\UserRepository;
+use App\Service;
 use App\Utils\ConstraintErrorsFormatter;
-use App\Utils\Locales;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -28,7 +28,7 @@ class PreferencesController extends BaseController
         return $this->render('preferences/edit.html.twig', [
             'colorScheme' => $user->getColorScheme(),
             'locale' => $user->getLocale(),
-            'availableLanguages' => Locales::getSupportedLanguages(),
+            'availableLanguages' => Service\Locales::SUPPORTED_LOCALES,
         ]);
     }
 
@@ -56,7 +56,7 @@ class PreferencesController extends BaseController
             return $this->renderBadRequest('preferences/edit.html.twig', [
                 'colorScheme' => $colorScheme,
                 'locale' => $locale,
-                'availableLanguages' => Locales::getSupportedLanguages(),
+                'availableLanguages' => Service\Locales::SUPPORTED_LOCALES,
                 'error' => $translator->trans('csrf.invalid', [], 'errors'),
             ]);
         }
@@ -71,7 +71,7 @@ class PreferencesController extends BaseController
             return $this->renderBadRequest('preferences/edit.html.twig', [
                 'colorScheme' => $colorScheme,
                 'locale' => $locale,
-                'availableLanguages' => Locales::getSupportedLanguages(),
+                'availableLanguages' => Service\Locales::SUPPORTED_LOCALES,
                 'errors' => ConstraintErrorsFormatter::format($errors),
             ]);
         }

--- a/src/Controller/SessionController.php
+++ b/src/Controller/SessionController.php
@@ -6,7 +6,7 @@
 
 namespace App\Controller;
 
-use App\Utils\Locales;
+use App\Service;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -19,6 +19,7 @@ class SessionController extends BaseController
     public function updateLocale(
         Request $request,
         RequestStack $requestStack,
+        Service\Locales $locales,
     ): Response {
         /** @var string $locale */
         $locale = $request->request->get('locale', $request->getLocale());
@@ -33,7 +34,7 @@ class SessionController extends BaseController
             return $this->redirectToRoute($from);
         }
 
-        if (!Locales::isAvailable($locale)) {
+        if (!$locales->isAvailable($locale)) {
             return $this->redirectToRoute($from);
         }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -9,9 +9,9 @@ namespace App\Entity;
 use App\ActivityMonitor\MonitorableEntityInterface;
 use App\ActivityMonitor\MonitorableEntityTrait;
 use App\Repository\UserRepository;
+use App\Service;
 use App\Uid\UidEntityInterface;
 use App\Uid\UidEntityTrait;
-use App\Utils\Locales;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -79,15 +79,15 @@ class User implements
     )]
     private ?string $colorScheme = 'auto';
 
-    #[ORM\Column(length: 5, options: ['default' => Locales::DEFAULT_LOCALE])]
+    #[ORM\Column(length: 5, options: ['default' => 'en_GB'])]
     #[Assert\NotBlank(
         message: new TranslatableMessage('user.language.required', [], 'errors'),
     )]
     #[Assert\Choice(
-        choices: Locales::SUPPORTED_LOCALES,
+        callback: [Service\Locales::class, 'getSupportedLocalesCodes'],
         message: new TranslatableMessage('user.language.invalid', [], 'errors'),
     )]
-    private ?string $locale = Locales::DEFAULT_LOCALE;
+    private ?string $locale = null;
 
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Length(
@@ -126,6 +126,7 @@ class User implements
     public function __construct()
     {
         $this->password = '';
+        $this->locale = 'en_GB';
         $this->authorizations = new ArrayCollection();
         $this->teams = new ArrayCollection();
     }

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -6,18 +6,23 @@
 
 namespace App\EventSubscriber;
 
-use App\Utils\Locales;
+use App\Service;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class LocaleSubscriber implements EventSubscriberInterface
 {
+    public function __construct(
+        private Service\Locales $locales,
+    ) {
+    }
+
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
 
-        $preferredLocale = Locales::getBest($request->getLanguages());
+        $preferredLocale = $this->locales->getBest($request->getLanguages());
         if ($request->hasPreviousSession()) {
             $locale = $request->getSession()->get('_locale', $preferredLocale);
             $request->setLocale($locale);

--- a/src/Service/Sorter/LocaleSorter.php
+++ b/src/Service/Sorter/LocaleSorter.php
@@ -6,18 +6,17 @@
 
 namespace App\Service\Sorter;
 
-use App\Utils\Locales;
+use App\Service;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class LocaleSorter
 {
-    private RequestStack $requestStack;
-
     private ?\Collator $collator = null;
 
-    public function __construct(RequestStack $requestStack)
-    {
-        $this->requestStack = $requestStack;
+    public function __construct(
+        private RequestStack $requestStack,
+        private Service\Locales $locales,
+    ) {
     }
 
     protected function getCollator(): \Collator
@@ -28,7 +27,7 @@ class LocaleSorter
             if ($currentRequest) {
                 $locale = $currentRequest->getLocale();
             } else {
-                $locale = Locales::DEFAULT_LOCALE;
+                $locale = $this->locales->getDefaultLocale();
             }
 
             $this->collator = new \Collator($locale);

--- a/src/Service/UserCreator.php
+++ b/src/Service/UserCreator.php
@@ -6,12 +6,9 @@
 
 namespace App\Service;
 
-use App\Entity\Organization;
-use App\Entity\User;
-use App\Repository\AuthorizationRepository;
-use App\Repository\OrganizationRepository;
-use App\Repository\RoleRepository;
-use App\Repository\UserRepository;
+use App\Entity;
+use App\Repository;
+use App\Service;
 use App\Utils;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -19,10 +16,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class UserCreator
 {
     public function __construct(
-        private AuthorizationRepository $authorizationRepository,
-        private OrganizationRepository $organizationRepository,
-        private RoleRepository $roleRepository,
-        private UserRepository $userRepository,
+        private Repository\AuthorizationRepository $authorizationRepository,
+        private Repository\OrganizationRepository $organizationRepository,
+        private Repository\RoleRepository $roleRepository,
+        private Repository\UserRepository $userRepository,
+        private Service\Locales $locales,
         private ValidatorInterface $validator,
         private UserPasswordHasherInterface $passwordHasher,
     ) {
@@ -32,12 +30,16 @@ class UserCreator
         string $email,
         string $name = '',
         string $password = '',
-        string $locale = Utils\Locales::DEFAULT_LOCALE,
+        string $locale = '',
         ?string $ldapIdentifier = null,
-        ?Organization $organization = null,
+        ?Entity\Organization $organization = null,
         bool $flush = true,
-    ): User {
-        $user = new User();
+    ): Entity\User {
+        if ($locale === '') {
+            $locale = $this->locales->getDefaultLocale();
+        }
+
+        $user = new Entity\User();
         $user->setEmail($email);
         $user->setName($name);
         $user->setLocale($locale);

--- a/tests/Service/LocalesTest.php
+++ b/tests/Service/LocalesTest.php
@@ -4,21 +4,35 @@
 // Copyright 2022-2024 Probesys
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace App\Tests\Utils;
+namespace App\Tests\Service;
 
-use App\Utils\Locales;
+use App\Service\Locales;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class LocalesTest extends TestCase
+class LocalesTest extends WebTestCase
 {
+    private Locales $locales;
+
+    #[Before]
+    public function setupTest(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        /** @var Locales */
+        $locales = $container->get(Locales::class);
+        $this->locales = $locales;
+    }
+
     /**
      * @param string[] $requestedLocales
      */
     #[DataProvider('englishRequestedLocale')]
     public function testGetBestWithEnglish(array $requestedLocales): void
     {
-        $locale = Locales::getBest($requestedLocales);
+        $locale = $this->locales->getBest($requestedLocales);
 
         $this->assertSame('en_GB', $locale);
     }
@@ -29,7 +43,7 @@ class LocalesTest extends TestCase
     #[DataProvider('frenchRequestedLocale')]
     public function testGetBestWithFrench(array $requestedLocales): void
     {
-        $locale = Locales::getBest($requestedLocales);
+        $locale = $this->locales->getBest($requestedLocales);
 
         $this->assertSame('fr_FR', $locale);
     }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/530

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Set `APP_DEFAULT_LOCALE=fr_FR` in your `.env.local` file
2. Reset the database `make db-reset FORCE=true`
3. Login with `alix@example.com` and verify that their locale is French
4. Create a user with CLI `./docker/bin/console app:user:create`
5. Login with this user and verify that their locale is French

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
