### PR TITLE
tec: Allow to setup/reset the database without the seeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,9 @@ install: ## Install the dependencies
 db-setup: ## Setup the database
 	$(CONSOLE) doctrine:database:create
 	$(CONSOLE) doctrine:migrations:migrate --no-interaction
+ifndef NO_SEED
 	$(CONSOLE) db:seeds:load
+endif
 
 .PHONY: db-migrate
 db-migrate: ## Migrate the database
@@ -102,7 +104,9 @@ endif
 	$(CONSOLE) doctrine:database:create
 	$(CONSOLE) doctrine:migrations:migrate --no-interaction
 	$(CONSOLE) cache:clear
+ifndef NO_SEED
 	$(CONSOLE) db:seeds:load
+endif
 ifndef NO_DOCKER
 	$(DOCKER_COMPOSE) start worker
 endif

--- a/docs/administrators/deploy.md
+++ b/docs/administrators/deploy.md
@@ -183,6 +183,9 @@ www-data$ php bin/console doctrine:migrations:migrate --no-interaction
 www-data$ php bin/console db:seeds:load
 ```
 
+The seeds provide some default roles: Technician, Salesman and User.
+It's not required to load the seeds if you don't want these roles.
+
 ### Configure the webserver
 
 Configure your webserver to serve Bileto.

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -91,3 +91,21 @@ $ ./docker/bin/console
 $ ./docker/bin/npm
 $ ./docker/bin/psql
 ```
+
+## Reset the database
+
+When developing, you may need to reset the database pretty often.
+You can do it with the following command:
+
+```console
+$ make db-reset FORCE=true
+```
+
+You need to pass the `FORCE` argument, or the command will not be executed.
+
+Resetting the database will also load the seeds.
+You can prevent this by passing the `NO_SEED` argument:
+
+```console
+$ make db-reset FORCE=true NO_SEED=true
+```


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

- run `make db-reset FORCE=true NO_SEED=true`
- create a user `./docker/bin/console app:users:create`
- login and verify that there is no data (especially no roles) except your users and the super-admin role

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
