### PR TITLE
Determine the default user's organization from their authorizations

### DIFF
--- a/docs/developers/roles.md
+++ b/docs/developers/roles.md
@@ -66,17 +66,28 @@ See below for the technical aspects of the teams authorizations.
 
 ### Granting roles to users
 
-You can grant a role to a user with the [`AuthorizationRepository`](/src/Repository/AuthorizationRepository.php):
+You can grant a role to a user with the [`Security\Authorizer`](/src/Security/Authorizer.php) service;
 
 ```php
+use App\Security\Authorizer;
+
 $user = /* get some user */;
 $role = /* get some role */;
 
-$authorizationRepository->grant($user, $role);
+$authorizer->grant($user, $role);
 
 // or, to grant a role scoped to a certain organization
 $organization = /* get some organization */;
-$authorizationRepository->grant($user, $role, $organization);
+$authorizer->grant($user, $role, $organization);
+```
+
+The authorizer can also grant a user to a team:
+
+```php
+$user = /* get some user */;
+$team = /* get some team */;
+
+$authorizer->grantToTeam($user, $team);
 ```
 
 ### Checking permissions with Symfony

--- a/src/Command/SeedsCommand.php
+++ b/src/Command/SeedsCommand.php
@@ -35,6 +35,7 @@ class SeedsCommand extends Command
         private Repository\RoleRepository $roleRepository,
         private Repository\TicketRepository $ticketRepository,
         private Repository\UserRepository $userRepository,
+        private Security\Authorizer $authorizer,
         private Security\Encryptor $encryptor,
         private Service\Locales $locales,
         private UserPasswordHasherInterface $passwordHasher,
@@ -176,19 +177,19 @@ class SeedsCommand extends Command
             $this->entityManager->flush();
 
             if (empty($this->authorizationRepository->getAdminAuthorizationsFor($userAlix))) {
-                $this->authorizationRepository->grant($userAlix, $roleSuper);
+                $this->authorizer->grant($userAlix, $roleSuper);
             }
 
             if (empty($this->authorizationRepository->getOrgaAuthorizationsFor($userAlix, $orgaFriendlyCoop))) {
-                $this->authorizationRepository->grant($userAlix, $roleTech, null);
+                $this->authorizer->grant($userAlix, $roleTech, null);
             }
 
             if (empty($this->authorizationRepository->getOrgaAuthorizationsFor($userBenedict, $orgaFriendlyCoop))) {
-                $this->authorizationRepository->grant($userBenedict, $roleSalesman, null);
+                $this->authorizer->grant($userBenedict, $roleSalesman, null);
             }
 
             if (empty($this->authorizationRepository->getOrgaAuthorizationsFor($userCharlie, $orgaFriendlyCoop))) {
-                $this->authorizationRepository->grant($userCharlie, $roleUser, $orgaFriendlyCoop);
+                $this->authorizer->grant($userCharlie, $roleUser, $orgaFriendlyCoop);
             }
 
             // Seed mailboxes

--- a/src/Command/Users/CreateCommand.php
+++ b/src/Command/Users/CreateCommand.php
@@ -7,6 +7,7 @@
 namespace App\Command\Users;
 
 use App\Repository;
+use App\Security;
 use App\Service;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -24,8 +25,8 @@ use Doctrine\Persistence\ManagerRegistry;
 class CreateCommand extends Command
 {
     public function __construct(
-        private Repository\AuthorizationRepository $authorizationRepository,
         private Repository\RoleRepository $roleRepository,
+        private Security\Authorizer $authorizer,
         private Service\Locales $locales,
         private Service\UserCreator $userCreator,
     ) {
@@ -103,7 +104,7 @@ class CreateCommand extends Command
         }
 
         $superRole = $this->roleRepository->findOrCreateSuperRole();
-        $this->authorizationRepository->grant($user, $superRole);
+        $this->authorizer->grant($user, $superRole);
 
         $output->writeln("The user \"{$user->getEmail()}\" has been created.");
 

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -21,6 +21,7 @@ use App\Service\ActorsLister;
 use App\Service\Sorter\LabelSorter;
 use App\Service\Sorter\OrganizationSorter;
 use App\Service\TicketTimeline;
+use App\Service\UserService;
 use App\Utils\Pagination;
 use App\Utils\Time;
 use Symfony\Component\HttpFoundation\Response;
@@ -122,6 +123,7 @@ class TicketsController extends BaseController
         AuthorizationRepository $authorizationRepository,
         OrganizationRepository $organizationRepository,
         OrganizationSorter $organizationSorter,
+        UserService $userService,
         Authorizer $authorizer,
     ): Response {
         $this->denyAccessUnlessGranted('orga:create:tickets', 'any');
@@ -133,7 +135,8 @@ class TicketsController extends BaseController
 
         // If the user has a default organization and can create tickets in it,
         // just redirect to the "new ticket" form of this organization.
-        $defaultOrganization = $user->getOrganization();
+        $defaultOrganization = $userService->getDefaultOrganization($user);
+
         if ($defaultOrganization && $authorizer->isGranted('orga:create:tickets', $defaultOrganization)) {
             return $this->redirectToRoute('new organization ticket', [
                 'uid' => $defaultOrganization->getUid(),

--- a/src/Controller/Users/AuthorizationsController.php
+++ b/src/Controller/Users/AuthorizationsController.php
@@ -9,7 +9,6 @@ namespace App\Controller\Users;
 use App\Controller\BaseController;
 use App\Entity\Authorization;
 use App\Entity\User;
-use App\Repository\AuthorizationRepository;
 use App\Repository\OrganizationRepository;
 use App\Repository\RoleRepository;
 use App\Security\Authorizer;
@@ -63,7 +62,6 @@ class AuthorizationsController extends BaseController
     public function create(
         User $holder,
         Request $request,
-        AuthorizationRepository $authorizationRepository,
         OrganizationRepository $organizationRepository,
         RoleRepository $roleRepository,
         OrganizationSorter $organizationSorter,
@@ -141,7 +139,7 @@ class AuthorizationsController extends BaseController
             ]);
         }
 
-        $authorizationRepository->grant($holder, $role, $organization);
+        $authorizer->grant($holder, $role, $organization);
 
         return $this->redirectToRoute('user', [
             'uid' => $holder->getUid(),
@@ -152,7 +150,6 @@ class AuthorizationsController extends BaseController
     public function delete(
         Authorization $authorization,
         Request $request,
-        AuthorizationRepository $authorizationRepository,
         Authorizer $authorizer,
         TranslatorInterface $translator,
     ): Response {
@@ -193,7 +190,7 @@ class AuthorizationsController extends BaseController
             ]);
         }
 
-        $authorizationRepository->remove($authorization, true);
+        $authorizer->ungrant($holder, $authorization);
 
         return $this->redirectToRoute('user', [
             'uid' => $holder->getUid(),

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -61,7 +61,7 @@ class UsersController extends BaseController
         $user = $form->getData();
         $userCreator->createUser($user);
 
-        return $this->redirectToRoute('user', [
+        return $this->redirectToRoute('new user authorization', [
             'uid' => $user->getUid(),
         ]);
     }

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -78,9 +78,12 @@ class UserForm extends AbstractType
                     'help' => $help,
                 ]);
             }
-        });
 
-        $builder->add('organization', AppType\OrganizationType::class);
+            $form->add('organization', AppType\OrganizationType::class, [
+                'permission' => 'orga:create:tickets',
+                'context_user' => $user,
+            ]);
+        });
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options): void

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -26,6 +26,7 @@ use App\Service\MessageDocumentStorage;
 use App\Service\MessageDocumentStorageError;
 use App\Service\UserCreator;
 use App\Service\UserCreatorException;
+use App\Service\UserService;
 use App\TicketActivity\MessageEvent;
 use App\TicketActivity\TicketEvent;
 use App\Utils;
@@ -49,6 +50,7 @@ class CreateTicketsFromMailboxEmailsHandler
         private TicketRepository $ticketRepository,
         private UserRepository $userRepository,
         private UserCreator $userCreator,
+        private UserService $userService,
         private Authorizer $authorizer,
         private HtmlSanitizerInterface $appMessageSanitizer,
         private LoggerInterface $logger,
@@ -86,11 +88,9 @@ class CreateTicketsFromMailboxEmailsHandler
                 continue;
             }
 
-            $requesterOrganization = $requester->getOrganization();
+            $requesterOrganization = $this->userService->getDefaultOrganization($requester);
 
-            if (!$requesterOrganization && $domainOrganization) {
-                $requesterOrganization = $domainOrganization;
-            } elseif (!$requesterOrganization) {
+            if (!$requesterOrganization) {
                 $this->markError($mailboxEmail, 'sender is not attached to an organization');
                 continue;
             }

--- a/src/Repository/AuthorizationRepository.php
+++ b/src/Repository/AuthorizationRepository.php
@@ -37,65 +37,6 @@ class AuthorizationRepository extends ServiceEntityRepository implements UidGene
         parent::__construct($registry, Authorization::class);
     }
 
-    public function grant(User $user, Role $role, ?Organization $organization = null): void
-    {
-        $authorization = new Authorization();
-        $authorization->setHolder($user);
-        $authorization->setRole($role);
-        $authorization->setOrganization($organization);
-        $this->save($authorization, true);
-    }
-
-    public function grantToTeam(User $user, Team $team): void
-    {
-        // Make sure to remove existing team authorizations of this user
-        $this->ungrantFromTeam($user, $team);
-
-        // Copy the team authorizations to the user.
-        $teamAuthorizations = $team->getTeamAuthorizations();
-        foreach ($teamAuthorizations as $teamAuthorization) {
-            $authorization = Authorization::fromTeamAuthorization($teamAuthorization);
-            $authorization->setHolder($user);
-
-            $this->getEntityManager()->persist($authorization);
-        }
-
-        $this->getEntityManager()->flush();
-    }
-
-    public function ungrantFromTeam(User $user, Team $team): void
-    {
-        $teamAuthorizations = $team->getTeamAuthorizations();
-
-        $authorizations = $this->findBy([
-            'holder' => $user,
-            'teamAuthorization' => $teamAuthorizations->toArray(),
-        ]);
-
-        foreach ($authorizations as $authorization) {
-            $this->getEntityManager()->remove($authorization);
-        }
-
-        $this->getEntityManager()->flush();
-    }
-
-    public function grantTeamAuthorization(Team $team, TeamAuthorization $teamAuthorization): void
-    {
-        if ($team->getId() !== $teamAuthorization->getTeam()->getId()) {
-            throw new \DomainException('Cannot grant this team authorization as it’s not attached to the given team.');
-        }
-
-        $users = $team->getAgents();
-        foreach ($users as $user) {
-            $authorization = Authorization::fromTeamAuthorization($teamAuthorization);
-            $authorization->setHolder($user);
-
-            $this->getEntityManager()->persist($authorization);
-        }
-
-        $this->getEntityManager()->flush();
-    }
-
     /**
      * @param AuthorizationType $authorizationType
      * @param ?Scope $scope

--- a/src/Repository/OrganizationRepository.php
+++ b/src/Repository/OrganizationRepository.php
@@ -51,14 +51,23 @@ class OrganizationRepository extends ServiceEntityRepository implements UidGener
     }
 
     /**
+     * @param 'any'|'user'|'agent' $roleType
+     *
      * @return Organization[]
      */
-    public function findAuthorizedOrganizations(User $user): array
+    public function findAuthorizedOrganizations(User $user, string $roleType = 'any'): array
     {
         $entityManager = $this->getEntityManager();
         /** @var AuthorizationRepository */
         $authorizationRepository = $entityManager->getRepository(Authorization::class);
         $authorizations = $authorizationRepository->getOrgaAuthorizationsFor($user, scope: 'any');
+
+        $authorizations = array_filter(
+            $authorizations,
+            function ($authorization) use ($roleType): bool {
+                return $roleType === 'any' || $authorization->getRole()->getType() === $roleType;
+            }
+        );
 
         $authorizedOrgaIds = array_map(function ($authorization): ?int {
             $organization = $authorization->getOrganization();

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -11,16 +11,15 @@ use App\Entity\Role;
 use App\Entity\Team;
 use App\Entity\TeamAuthorization;
 use App\Entity\User;
-use App\Repository\AuthorizationRepository;
-use App\Repository\TeamRepository;
-use App\Repository\TeamAuthorizationRepository;
+use App\Repository;
+use App\Security;
 
 class TeamService
 {
     public function __construct(
-        private AuthorizationRepository $authorizationRepository,
-        private TeamRepository $teamRepository,
-        private TeamAuthorizationRepository $teamAuthorizationRepository,
+        private Repository\TeamRepository $teamRepository,
+        private Repository\TeamAuthorizationRepository $teamAuthorizationRepository,
+        private Security\Authorizer $authorizer,
     ) {
     }
 
@@ -28,8 +27,10 @@ class TeamService
     {
         if (!$team->hasAgent($agent)) {
             $team->addAgent($agent);
+
             $this->teamRepository->save($team, true);
-            $this->authorizationRepository->grantToTeam($agent, $team);
+
+            $this->authorizer->grantToTeam($agent, $team);
         }
     }
 
@@ -37,8 +38,10 @@ class TeamService
     {
         if ($team->hasAgent($agent)) {
             $team->removeAgent($agent);
+
             $this->teamRepository->save($team, true);
-            $this->authorizationRepository->ungrantFromTeam($agent, $team);
+
+            $this->authorizer->ungrantFromTeam($agent, $team);
         }
     }
 
@@ -50,7 +53,8 @@ class TeamService
         $teamAuthorization->setOrganization($organization);
 
         $this->teamAuthorizationRepository->save($teamAuthorization, true);
-        $this->authorizationRepository->grantTeamAuthorization($team, $teamAuthorization);
+
+        $this->authorizer->grantTeamAuthorization($team, $teamAuthorization);
     }
 
     public function removeAuthorization(TeamAuthorization $teamAuthorization): void

--- a/src/Service/UserCreator.php
+++ b/src/Service/UserCreator.php
@@ -8,6 +8,7 @@ namespace App\Service;
 
 use App\Entity;
 use App\Repository;
+use App\Security;
 use App\Service;
 use App\Utils;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -16,9 +17,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class UserCreator
 {
     public function __construct(
-        private Repository\AuthorizationRepository $authorizationRepository,
         private Repository\RoleRepository $roleRepository,
         private Repository\UserRepository $userRepository,
+        private Security\Authorizer $authorizer,
         private Service\Locales $locales,
         private Service\UserService $userService,
         private ValidatorInterface $validator,
@@ -45,7 +46,7 @@ class UserCreator
             $defaultOrganization = $this->userService->getDefaultOrganization($user);
 
             if ($defaultOrganization) {
-                $this->authorizationRepository->grant(
+                $this->authorizer->grant(
                     $user,
                     $defaultRole,
                     $defaultOrganization,

--- a/src/Service/UserCreator.php
+++ b/src/Service/UserCreator.php
@@ -17,10 +17,10 @@ class UserCreator
 {
     public function __construct(
         private Repository\AuthorizationRepository $authorizationRepository,
-        private Repository\OrganizationRepository $organizationRepository,
         private Repository\RoleRepository $roleRepository,
         private Repository\UserRepository $userRepository,
         private Service\Locales $locales,
+        private Service\UserService $userService,
         private ValidatorInterface $validator,
         private UserPasswordHasherInterface $passwordHasher,
     ) {
@@ -42,20 +42,13 @@ class UserCreator
 
         $defaultRole = $this->roleRepository->findDefault();
         if ($defaultRole) {
-            $organization = $user->getOrganization();
+            $defaultOrganization = $this->userService->getDefaultOrganization($user);
 
-            if ($organization) {
-                $authorizationOrganization = $organization;
-            } else {
-                $emailDomain = Utils\Email::extractDomain($user->getEmail());
-                $authorizationOrganization = $this->organizationRepository->findOneByDomainOrDefault($emailDomain);
-            }
-
-            if ($authorizationOrganization) {
+            if ($defaultOrganization) {
                 $this->authorizationRepository->grant(
                     $user,
                     $defaultRole,
-                    $authorizationOrganization,
+                    $defaultOrganization,
                 );
             }
         }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -1,0 +1,37 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Service;
+
+use App\Entity;
+use App\Repository;
+use App\Utils;
+
+class UserService
+{
+    public function __construct(
+        private Repository\OrganizationRepository $organizationRepository,
+    ) {
+    }
+
+    public function getDefaultOrganization(Entity\User $user): ?Entity\Organization
+    {
+        $organization = $user->getOrganization();
+
+        if ($organization) {
+            return $organization;
+        }
+
+        $domain = Utils\Email::extractDomain($user->getEmail());
+        $domainOrganization = $this->organizationRepository->findOneByDomainOrDefault($domain);
+
+        if ($domainOrganization) {
+            return $domainOrganization;
+        }
+
+        return null;
+    }
+}

--- a/templates/users/_form.html.twig
+++ b/templates/users/_form.html.twig
@@ -161,40 +161,44 @@
         </div>
     {% endif %}
 
-    <div class="flow flow--small">
-        <label for="{{ field_id(form.organization) }}">
-            {{ 'users.organization' | trans }}
-        </label>
+    {% if form.organization.vars.choices is not empty %}
+        <div class="flow flow--small">
+            <label for="{{ field_id(form.organization) }}">
+                {{ 'users.organization' | trans }}
+            </label>
 
-        <p class="form__caption" id="{{ field_id(form.organization, 'caption') }}">
-            {{ 'users.form.organization_caption' | trans }}
-        </p>
+            <p class="form__caption" id="{{ field_id(form.organization, 'caption') }}">
+                {{ 'users.form.organization_caption' | trans }}
+            </p>
 
-        {{ form_errors(form.organization) }}
+            {{ form_errors(form.organization) }}
 
-        <select
-            id="{{ field_id(form.organization) }}"
-            name="{{ field_name(form.organization) }}"
-            aria-describedby="{{ field_id(form.organization, 'caption') }}"
-            {% if field_has_errors(form.organization) %}
-                aria-invalid="true"
-                aria-errormessage="{{ field_id(form.organization, 'error') }}"
-            {% endif %}
-        >
-            <option value="">
-                {{ 'users.no_organization' | trans }}
-            </option>
-
-            {% for choice in form.organization.vars.choices %}
-                <option
-                    value="{{ choice.value }}"
-                    {{ choice.value == field_value(form.organization) ? 'selected' }}
-                >
-                    {{ choice.label }}
+            <select
+                id="{{ field_id(form.organization) }}"
+                name="{{ field_name(form.organization) }}"
+                aria-describedby="{{ field_id(form.organization, 'caption') }}"
+                {% if field_has_errors(form.organization) %}
+                    aria-invalid="true"
+                    aria-errormessage="{{ field_id(form.organization, 'error') }}"
+                {% endif %}
+            >
+                <option value="">
+                    {{ 'users.no_organization' | trans }}
                 </option>
-            {% endfor %}
-        </select>
-    </div>
+
+                {% for choice in form.organization.vars.choices %}
+                    <option
+                        value="{{ choice.value }}"
+                        {{ choice.value == field_value(form.organization) ? 'selected' }}
+                    >
+                        {{ choice.label }}
+                    </option>
+                {% endfor %}
+            </select>
+        </div>
+    {% else %}
+        <!-- {{ field_name(form.organization) }} -->
+    {% endif %}
 
     <div class="form__actions">
         <button class="button--primary" type="submit">

--- a/templates/users/show.html.twig
+++ b/templates/users/show.html.twig
@@ -80,10 +80,6 @@
                         <p>
                             {{ 'users.show.organization' | trans({ name: user.organization.name }) }}
                         </p>
-                    {% else %}
-                        <p>
-                            {{ 'users.show.organization.none' | trans }}
-                        </p>
                     {% endif %}
                 </div>
             </div>
@@ -98,19 +94,6 @@
                     {{ 'users.show.authorizations.new' | trans }}
                 </a>
             </div>
-
-            {% if user.organization and not is_granted_to_user(user, 'orga:create:tickets', user.organization) %}
-                <div class="wrapper wrapper--text wrapper--center">
-                    {{ include('alerts/_alert.html.twig', {
-                        type: 'warning',
-                        title: 'common.caution' | trans,
-                        message: 'users.no_organization_authorization' | trans({
-                            path: path('new user authorization', { uid: user.uid, orga: user.organization.uid }),
-                        }),
-                        raw: true,
-                    }) }}
-                </div>
-            {% endif %}
 
             <div class="grid">
                 {% for authorization in authorizations %}

--- a/tests/AuthorizationHelper.php
+++ b/tests/AuthorizationHelper.php
@@ -11,9 +11,9 @@ use App\Entity\Organization;
 use App\Entity\Role;
 use App\Entity\Team;
 use App\Entity\User;
-use App\Service\TeamService;
-use App\Utils\Random;
-use App\Utils\Time;
+use App\Security;
+use App\Service;
+use App\Utils;
 use Doctrine\ORM\EntityManager;
 
 trait AuthorizationHelper
@@ -28,28 +28,29 @@ trait AuthorizationHelper
         }
 
         $container = static::getContainer();
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $registry */
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry */
         $registry = $container->get('doctrine');
         $entityManager = $registry->getManager();
 
-        /** @var \App\Repository\RoleRepository $roleRepo */
+        /** @var \App\Repository\RoleRepository */
         $roleRepo = $entityManager->getRepository(Role::class);
-        /** @var \App\Repository\AuthorizationRepository $authorizationRepo */
-        $authorizationRepo = $entityManager->getRepository(Authorization::class);
+
+        /** @var Security\Authorizer */
+        $authorizer = $container->get(Security\Authorizer::class);
 
         $superPermissionGranted = in_array('admin:*', $permissions);
         if ($superPermissionGranted) {
             $role = $roleRepo->findOrCreateSuperRole();
-            $authorizationRepo->grant($user, $role);
+            $authorizer->grant($user, $role);
         } else {
             $role = new Role();
-            $role->setName(Random::hex(10));
+            $role->setName(Utils\Random::hex(10));
             $role->setDescription('The role description');
             $role->setType('admin');
             $role->setPermissions($permissions);
 
             $roleRepo->save($role);
-            $authorizationRepo->grant($user, $role);
+            $authorizer->grant($user, $role);
         }
     }
 
@@ -68,23 +69,24 @@ trait AuthorizationHelper
         }
 
         $container = static::getContainer();
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $registry */
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry */
         $registry = $container->get('doctrine');
         $entityManager = $registry->getManager();
 
-        /** @var \App\Repository\RoleRepository $roleRepo */
+        /** @var \App\Repository\RoleRepository */
         $roleRepo = $entityManager->getRepository(Role::class);
-        /** @var \App\Repository\AuthorizationRepository $authorizationRepo */
-        $authorizationRepo = $entityManager->getRepository(Authorization::class);
+
+        /** @var Security\Authorizer */
+        $authorizer = $container->get(Security\Authorizer::class);
 
         $role = new Role();
-        $role->setName(Random::hex(10));
+        $role->setName(Utils\Random::hex(10));
         $role->setDescription('The role description');
         $role->setType($type);
         $role->setPermissions($permissions);
 
         $roleRepo->save($role);
-        $authorizationRepo->grant($user, $role, $organization);
+        $authorizer->grant($user, $role, $organization);
     }
 
     /**
@@ -100,17 +102,17 @@ trait AuthorizationHelper
         }
 
         $container = static::getContainer();
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry $registry */
+        /** @var \Doctrine\Bundle\DoctrineBundle\Registry */
         $registry = $container->get('doctrine');
         $entityManager = $registry->getManager();
 
         /** @var \App\Repository\RoleRepository */
         $roleRepo = $entityManager->getRepository(Role::class);
-        /** @var TeamService */
-        $teamService = $container->get(TeamService::class);
+        /** @var Service\TeamService */
+        $teamService = $container->get(Service\TeamService::class);
 
         $role = new Role();
-        $role->setName(Random::hex(10));
+        $role->setName(Utils\Random::hex(10));
         $role->setDescription('The role description');
         $role->setType('agent');
         $role->setPermissions($permissions);

--- a/tests/Security/AuthorizerTest.php
+++ b/tests/Security/AuthorizerTest.php
@@ -28,23 +28,15 @@ class AuthorizerTest extends WebTestCase
 
     private Authorizer $authorizer;
 
-    private AuthorizationRepository $authRepository;
-
     #[Before]
     public function setupTest(): void
     {
         $this->client = static::createClient();
         $container = static::getContainer();
+
         /** @var Authorizer */
         $authorizer = $container->get(Authorizer::class);
         $this->authorizer = $authorizer;
-
-        /** @var \Doctrine\Bundle\DoctrineBundle\Registry */
-        $registry = $container->get('doctrine');
-        $entityManager = $registry->getManager();
-        /** @var AuthorizationRepository */
-        $authRepository = $entityManager->getRepository(Authorization::class);
-        $this->authRepository = $authRepository;
     }
 
     public function testIsAgentWithAgentRole(): void
@@ -54,7 +46,7 @@ class AuthorizerTest extends WebTestCase
         $role = RoleFactory::createOne([
             'type' => 'agent',
         ])->_real();
-        $this->authRepository->grant($user, $role, null);
+        $this->authorizer->grant($user, $role, null);
 
         $isAgent = $this->authorizer->isAgent('any');
 
@@ -70,7 +62,7 @@ class AuthorizerTest extends WebTestCase
         ])->_real();
         $organization1 = OrganizationFactory::createOne()->_real();
         $organization2 = OrganizationFactory::createOne()->_real();
-        $this->authRepository->grant($user, $role, $organization1);
+        $this->authorizer->grant($user, $role, $organization1);
 
         $isAgent = $this->authorizer->isAgent('any');
         $this->assertTrue($isAgent);
@@ -89,7 +81,7 @@ class AuthorizerTest extends WebTestCase
         $role = RoleFactory::createOne([
             'type' => 'user',
         ])->_real();
-        $this->authRepository->grant($user, $role, null);
+        $this->authorizer->grant($user, $role, null);
 
         $isAgent = $this->authorizer->isAgent('any');
 
@@ -115,7 +107,7 @@ class AuthorizerTest extends WebTestCase
         $role = RoleFactory::createOne([
             'type' => 'agent',
         ])->_real();
-        $this->authRepository->grant($user, $role, null);
+        $this->authorizer->grant($user, $role, null);
 
         $isAgent = $this->authorizer->isAgent('any');
 

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Service;
+
+use App\Service;
+use App\Tests;
+use App\Tests\Factory\AuthorizationFactory;
+use App\Tests\Factory\OrganizationFactory;
+use App\Tests\Factory\RoleFactory;
+use App\Tests\Factory\UserFactory;
+use PHPUnit\Framework\Attributes\Before;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class UserServiceTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+    use Tests\AuthorizationHelper;
+
+    private Service\UserService $userService;
+
+    #[Before]
+    public function setupTest(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        /** @var Service\UserService */
+        $userService = $container->get(Service\UserService::class);
+        $this->userService = $userService;
+    }
+
+    public function testGetDefaultOrganizationWithDeclaredDefaultOrganization(): void
+    {
+        $organization1 = OrganizationFactory::createOne();
+        $organization2 = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization1,
+        ]);
+
+        $defaultOrganization = $this->userService->getDefaultOrganization($user->_real());
+
+        $this->assertNotNull($defaultOrganization);
+        $this->assertSame($organization1->getId(), $defaultOrganization->getId());
+    }
+
+    public function testGetDefaultOrganizationWithOrganizationDomain(): void
+    {
+        $organization1 = OrganizationFactory::createOne([
+            'domains' => ['example.com'],
+        ]);
+        $organization2 = OrganizationFactory::createOne([
+            'domains' => ['example.org'],
+        ]);
+        $user = UserFactory::createOne([
+            'email' => 'alix@example.com',
+            'organization' => null,
+        ]);
+
+        $defaultOrganization = $this->userService->getDefaultOrganization($user->_real());
+
+        $this->assertNotNull($defaultOrganization);
+        $this->assertSame($organization1->getId(), $defaultOrganization->getId());
+    }
+
+    public function testGetDefaultOrganizationWithGivenUserAuthorization(): void
+    {
+        $organization1 = OrganizationFactory::createOne();
+        $organization2 = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => null,
+        ]);
+        $this->grantOrga(
+            $user->_real(),
+            ['orga:create:tickets'],
+            $organization1->_real(),
+            'user',
+        );
+
+        $defaultOrganization = $this->userService->getDefaultOrganization($user->_real());
+
+        $this->assertNotNull($defaultOrganization);
+        $this->assertSame($organization1->getId(), $defaultOrganization->getId());
+    }
+
+    public function testGetDefaultOrganizationReturnsNullWithAgentAuthorization(): void
+    {
+        $organization1 = OrganizationFactory::createOne();
+        $organization2 = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => null,
+        ]);
+        $this->grantOrga(
+            $user->_real(),
+            ['orga:create:tickets'],
+            $organization1->_real(),
+            'agent',
+        );
+
+        $defaultOrganization = $this->userService->getDefaultOrganization($user->_real());
+
+        $this->assertNull($defaultOrganization);
+    }
+
+    public function testGetDefaultOrganizationReturnsNullOtherwise(): void
+    {
+        $organization1 = OrganizationFactory::createOne();
+        $organization2 = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => null,
+        ]);
+
+        $defaultOrganization = $this->userService->getDefaultOrganization($user->_real());
+
+        $this->assertNull($defaultOrganization);
+    }
+}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -537,7 +537,6 @@ users.n_others: '{number, plural, =0 {no other} one {1 other} other {# other}}'
 users.name: Name
 users.new.submit: 'Create the user'
 users.new.title: 'New user'
-users.no_organization_authorization: 'This user cannot create tickets in their organisation by default. Remember to <a href="{path}">give this user the appropriate authorization.</a>'
 users.no_organization: 'No organization'
 users.organization: Organization
 users.password: Password
@@ -548,6 +547,5 @@ users.show.email: 'Email: {email}'
 users.show.ldap_identifier: 'LDAP identifier: {identifier}'
 users.show.name: 'Name: {name}'
 users.show.organization: 'Organization: {name}'
-users.show.organization.none: 'Organization: None'
 users.show.profile: 'User profile'
 users.yourself: yourself

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -537,7 +537,6 @@ users.n_others: '{number, plural, =0 {aucun autre} one {1 autre} other {# autres
 users.name: Nom
 users.new.submit: 'Créer l’utilisateur'
 users.new.title: 'Nouvel utilisateur'
-users.no_organization_authorization: 'Cet utilisateur ne peut pas créer de tickets dans son organisation par défaut. Pensez à lui <a href="{path}">donner une autorisation correspondante.</a>'
 users.no_organization: 'Aucune organisation'
 users.organization: Organisation
 users.password: 'Mot de passe'
@@ -548,6 +547,5 @@ users.show.email: "Email\_: {email}"
 users.show.ldap_identifier: "Identifiant LDAP\_: {identifier}"
 users.show.name: "Nom\_: {name}"
 users.show.organization: "Organisation\_: {name}"
-users.show.organization.none: "Organisation\_: Aucune"
 users.show.profile: 'Profil utilisateur'
 users.yourself: vous


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->
https://github.com/Probesys/bileto/issues/747

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create a user
2. Verify that you cannot select an organization at this step
3. Verify that you're redirected to the authorization form
4. Give a "user authorization" to the user on a specific organization
5. Login with this user
6. Verify that you can create a ticket with this user
7. As an admin, edit the user
8. Verify that you can now select a default organization and that only one organization is selectable

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
