### PR TITLE
fix: Fix the timeline bar height

### DIFF
--- a/assets/javascripts/controllers/timeline_controller.js
+++ b/assets/javascripts/controllers/timeline_controller.js
@@ -6,6 +6,13 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
     connect () {
+        this.resizeBar();
+
+        const resizeObserver = new ResizeObserver(() => this.resizeBar());
+        resizeObserver.observe(this.element);
+    }
+
+    resizeBar () {
         const bottom = this.element.querySelector('#bottom');
 
         let lastElement = null


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create a ticket and post some other answers with big images
2. Refresh the browser tab
3. Verify that the timeline bar on the left goes to the last element of the timeline

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
