### PR TITLE
fix: Don't show "unassigned buttons" if ticket is closed

### DIFF
--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -239,7 +239,7 @@
 
                                 {% if ticket.assignee %}
                                     {{ ticket.assignee.displayName }}
-                                {% elseif is_granted('orga:update:tickets:actors', organization) %}
+                                {% elseif is_granted('orga:update:tickets:actors', organization) and not ticket.isClosed %}
                                     <button
                                         class="button--anchor"
                                         data-controller="modal-opener"


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/275

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. create a ticket and close it without assigning an agent to it
2. verify that the "unassigned" label cannot be clicked

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
