### PR TITLE
fix: Fix LDAP sync when creating new users

### DIFF
--- a/src/Repository/AuthorizationRepository.php
+++ b/src/Repository/AuthorizationRepository.php
@@ -100,6 +100,10 @@ class AuthorizationRepository extends ServiceEntityRepository implements UidGene
      */
     public function loadUserAuthorizations(User $user): array
     {
+        if ($user->getId() === null) {
+            return [];
+        }
+
         $keyCache = $user->getUid();
 
         if (!isset($this->cacheAuthorizations[$keyCache])) {


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

https://github.com/Probesys/bileto/issues/763

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Create a default user role
2. Setup a LDAP server
3. Make sure the LDAP users' emails are not handled by any organization (e.g. no `*` domain)
4. Synchronize the LDAP users
5. Verify that the synchronization doesn't fail

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
