### PR TITLE
dev: Enable LDAP server by default in dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ else
 	DOCKER_COMPOSE_PROFILE = --profile pgsql
 endif
 
-ifdef LDAP
-	DOCKER_COMPOSE_PROFILE += --profile ldap
-endif
-
 ifndef COVERAGE
 	COVERAGE = --coverage-html ./coverage
 endif
@@ -61,7 +57,7 @@ docker-pull: ## Pull the Docker images from the Docker Hub
 
 .PHONY: docker-clean
 docker-clean: ## Clean the Docker stuff
-	$(DOCKER_COMPOSE) --profile pgsql --profile mariadb --profile ldap down -v
+	$(DOCKER_COMPOSE) --profile pgsql --profile mariadb down -v
 
 .PHONY: docker-image
 docker-image: ## Build the Docker image for production (take a VERSION argument)

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -83,5 +83,3 @@ services:
             - BITNAMI_DEBUG=true
         volumes:
             - ./ldap-ldifs:/ldifs:z
-        profiles:
-            - ldap

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -58,14 +58,7 @@ If you want to make this change permanent, create a `.env.local` file and copy t
 
 ## Work with LDAP
 
-The LDAP server is not started by default.
-To start the LDAP server, pass the `LDAP` variable to the command:
-
-```console
-$ make docker-start LDAP=true
-```
-
-You’ll also have to create an `.env.local` file to enable LDAP support in Bileto:
+You’ll have to create an `.env.local` file to enable LDAP support in Bileto:
 
 ```dotenv
 LDAP_ENABLED=true


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable). -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable). -->

1. Run the dev env with `make docker-start`
2. Verify that the LDAP container is started

## Checklist

<!-- Make sure all the todos are checked before asking for review. If you think
  -- one of the item isn’t applicable to this PR, please check it anyway and
  -- precise "N/A" next to it.
  -- Get help: https://github.com/Probesys/bileto/blob/main/CONTRIBUTING.md#open-a-pull-request-pr
  -->

- [x] code is manually tested
- [x] permissions / authorizations are verified
- [x] data can be imported correctly
- [x] interface works on both mobiles and big screens
- [x] interface works in both light and dark modes
- [x] interface works on both Firefox and Chrome
- [x] accessibility has been tested
- [x] tests are up-to-date
- [x] locales are synchronized
- [x] copyright notices are up to date
- [x] documentation is up to date (including migration notes)
