### PR TITLE
tec: Associate time spent with corresponding message

### DIFF
--- a/migrations/Version20241119150300AddMessageToTimeSpent.php
+++ b/migrations/Version20241119150300AddMessageToTimeSpent.php
@@ -1,0 +1,51 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2024 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20241119150300AddMessageToTimeSpent extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the message_id column to the time_spent table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE time_spent ADD message_id INT DEFAULT NULL');
+            $this->addSql('ALTER TABLE time_spent ADD CONSTRAINT FK_B417D625537A1329 FOREIGN KEY (message_id) REFERENCES message (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+            $this->addSql('CREATE INDEX IDX_B417D625537A1329 ON time_spent (message_id)');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE time_spent ADD message_id INT DEFAULT NULL');
+            $this->addSql('ALTER TABLE time_spent ADD CONSTRAINT FK_B417D625537A1329 FOREIGN KEY (message_id) REFERENCES message (id) ON DELETE SET NULL');
+            $this->addSql('CREATE INDEX IDX_B417D625537A1329 ON time_spent (message_id)');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE time_spent DROP CONSTRAINT FK_B417D625537A1329');
+            $this->addSql('DROP INDEX IDX_B417D625537A1329');
+            $this->addSql('ALTER TABLE time_spent DROP message_id');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE time_spent DROP FOREIGN KEY FK_B417D625537A1329');
+            $this->addSql('DROP INDEX IDX_B417D625537A1329 ON time_spent');
+            $this->addSql('ALTER TABLE time_spent DROP message_id');
+        }
+    }
+}

--- a/src/Controller/Tickets/MessagesController.php
+++ b/src/Controller/Tickets/MessagesController.php
@@ -65,7 +65,7 @@ class MessagesController extends BaseController
 
         $minutesSpent = $form->has('timeSpent') ? $form->get('timeSpent')->getData() : 0;
         if ($minutesSpent > 0) {
-            $ticketTimeAccounting->accountTime($ticket, $minutesSpent);
+            $ticketTimeAccounting->accountTime($minutesSpent, $ticket, $message);
         }
 
         $type = $form->has('type') ? $form->get('type')->getData() : 'normal';

--- a/src/Entity/TimeSpent.php
+++ b/src/Entity/TimeSpent.php
@@ -72,6 +72,10 @@ class TimeSpent implements EntityInterface, MonitorableEntityInterface, UidEntit
     #[ORM\JoinColumn(onDelete: 'SET NULL')]
     private ?Contract $contract = null;
 
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    private ?Message $message = null;
+
     public function getTicket(): ?Ticket
     {
         return $this->ticket;
@@ -123,5 +127,17 @@ class TimeSpent implements EntityInterface, MonitorableEntityInterface, UidEntit
     public function getTimelineType(): string
     {
         return 'time_spent';
+    }
+
+    public function getMessage(): ?Message
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?Message $message): static
+    {
+        $this->message = $message;
+
+        return $this;
     }
 }

--- a/src/Service/TicketTimeAccounting.php
+++ b/src/Service/TicketTimeAccounting.php
@@ -25,8 +25,11 @@ class TicketTimeAccounting
      *
      * @param positive-int $minutes
      */
-    public function accountTime(Entity\Ticket $ticket, int $minutes): void
-    {
+    public function accountTime(
+        int $minutes,
+        Entity\Ticket $ticket,
+        ?Entity\Message $message = null,
+    ): void {
         $contract = $ticket->getOngoingContract();
 
         if (!$contract) {
@@ -34,6 +37,7 @@ class TicketTimeAccounting
             $timeSpent->setTicket($ticket);
             $timeSpent->setTime($minutes);
             $timeSpent->setRealTime($minutes);
+            $timeSpent->setMessage($message);
 
             $this->timeSpentRepository->save($timeSpent, true);
 
@@ -42,6 +46,7 @@ class TicketTimeAccounting
 
         $timeSpent = $this->contractTimeAccounting->accountTime($contract, $minutes);
         $timeSpent->setTicket($ticket);
+        $timeSpent->setMessage($message);
 
         $this->timeSpentRepository->save($timeSpent, true);
 
@@ -54,6 +59,7 @@ class TicketTimeAccounting
             $timeSpent->setTicket($ticket);
             $timeSpent->setTime($remainingUnaccountedTime);
             $timeSpent->setRealTime($remainingUnaccountedTime);
+            $timeSpent->setMessage($message);
 
             $this->timeSpentRepository->save($timeSpent, true);
         }

--- a/tests/Controller/Tickets/MessagesControllerTest.php
+++ b/tests/Controller/Tickets/MessagesControllerTest.php
@@ -224,9 +224,11 @@ class MessagesControllerTest extends WebTestCase
             ],
         ]);
 
+        $message = Factory\MessageFactory::last();
         $timeSpent = Factory\TimeSpentFactory::first();
         $this->assertSame(20, $timeSpent->getTime());
         $this->assertSame($ticket->getId(), $timeSpent->getTicket()->getId());
+        $this->assertSame($message->getId(), $timeSpent->getMessage()->getId());
     }
 
     public function testPostCanAssociateTimeSpentToContract(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/612

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Answer with a message containing the string `#oncall` and add time spent
2. In the database (`./docker/bin/psql bileto`), run:

```sql
SELECT u.email, SUM(ts.real_time)
FROM time_spent ts, users u, message m
WHERE ts.created_by_id = u.id
AND ts.message_id = m.id
AND m.content LIKE '%#oncall%'
AND ts.created_at >= '2024-11-01'
AND ts.created_at < '2024-12-01'
GROUP BY u.email;
```

3. verify it shows the time spent

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported (see https://github.com/Probesys/bileto/issues/751)
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
