### PR TITLE
imp: Display the user organization automatically calculated

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -61,8 +61,11 @@ class UsersController extends BaseController
         Entity\User $user,
         Repository\AuthorizationRepository $authorizationRepository,
         Sorter\AuthorizationSorter $authorizationSorter,
+        Service\UserService $userService,
     ): Response {
         $this->denyAccessUnlessGranted('admin:manage:users');
+
+        $defaultOrganization = $userService->getDefaultOrganization($user);
 
         $authorizations = $authorizationRepository->findBy([
             'holder' => $user,
@@ -71,6 +74,7 @@ class UsersController extends BaseController
 
         return $this->render('users/show.html.twig', [
             'user' => $user,
+            'defaultOrganization' => $defaultOrganization,
             'authorizations' => $authorizations,
         ]);
     }

--- a/templates/users/show.html.twig
+++ b/templates/users/show.html.twig
@@ -76,11 +76,15 @@
                         </p>
                     {% endif %}
 
-                    {% if user.organization %}
-                        <p>
+                    <p>
+                        {% if user.organization %}
                             {{ 'users.show.organization' | trans({ name: user.organization.name }) }}
-                        </p>
-                    {% endif %}
+                        {% elseif defaultOrganization %}
+                            {{ 'users.show.organization_automatic' | trans({ name: defaultOrganization.name }) }}
+                        {% else %}
+                            {{ 'users.show.no_organization' | trans }}
+                        {% endif %}
+                    </p>
                 </div>
             </div>
         </div>

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -550,6 +550,8 @@ users.show.edit: 'Edit the user'
 users.show.email: 'Email: {email}'
 users.show.ldap_identifier: 'LDAP identifier: {identifier}'
 users.show.name: 'Name: {name}'
+users.show.no_organization: 'Organization: None'
 users.show.organization: 'Organization: {name}'
+users.show.organization_automatic: 'Organization: {name} (automatic)'
 users.show.profile: 'User profile'
 users.yourself: yourself

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -550,6 +550,8 @@ users.show.edit: 'Modifier l’utilisateur'
 users.show.email: "Email\_: {email}"
 users.show.ldap_identifier: "Identifiant LDAP\_: {identifier}"
 users.show.name: "Nom\_: {name}"
+users.show.no_organization: "Organisation\_: Aucune"
 users.show.organization: "Organisation\_: {name}"
+users.show.organization_automatic: "Organisation\_: {name} (automatique)"
 users.show.profile: 'Profil utilisateur'
 users.yourself: vous


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/795

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Make sure no organization has "domains"
1. Create a user without authorization
2. Verify the user has no "Organization" on its page
3. Add an authorization to the user on a specific organization
5. Verify the user has the corresponding organization on its page (marked as "Automatic")
4. Add the domain of the user to another organization
5. Verify the user has the corresponding organization on its page (marked as "Automatic")
6. Force the user's organization with the edit form
5. Verify the user has the corresponding organization on its page

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
