### PR TITLE
tec: Ignore autoresponse emails when collecting emails

### DIFF
--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -138,6 +138,27 @@ class MailboxEmail implements EntityInterface, MonitorableEntityInterface, UidEn
         return $inReplyTo;
     }
 
+    public function isAutoreply(): bool
+    {
+        $email = $this->getEmail();
+
+        $isAutosubmitted = false;
+        $autosubmittedHeader = $email->get('Auto-Submitted');
+        if ($autosubmittedHeader instanceof PHPIMAP\Attribute) {
+            $autosubmitted = $autosubmittedHeader->first();
+            $isAutosubmitted = $autosubmitted !== false && $autosubmitted !== 'no';
+        }
+
+        $isAutoreply = false;
+        $autoreplyHeader = $email->get('X-Autoreply');
+        if ($autoreplyHeader instanceof PHPIMAP\Attribute) {
+            $autoreply = $autoreplyHeader->first();
+            $isAutoreply = $autoreply !== false && $autoreply === 'yes';
+        }
+
+        return $isAutosubmitted || $isAutoreply;
+    }
+
     public function getSubject(): string
     {
         return $this->getEmail()->getSubject();

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -92,6 +92,14 @@ class CreateTicketsFromMailboxEmailsHandler
 
     private function processMailboxEmail(MailboxEmail $mailboxEmail): void
     {
+        if ($mailboxEmail->isAutoreply()) {
+            $this->logger->notice("MailboxEmail #{$mailboxEmail->getId()} ignored: detected as auto reply");
+
+            $this->mailboxEmailRepository->remove($mailboxEmail, true);
+
+            return;
+        }
+
         $senderEmail = $mailboxEmail->getFrom();
 
         $domain = Utils\Email::extractDomain($senderEmail);

--- a/src/MessageHandler/SendMessageEmailHandler.php
+++ b/src/MessageHandler/SendMessageEmailHandler.php
@@ -131,6 +131,9 @@ class SendMessageEmailHandler
             }
         }
 
+        // Ask compliant autoresponders to not reply to this email
+        $email->getHeaders()->addTextHeader('X-Auto-Response-Suppress', 'All');
+
         $sentEmail = $this->transportInterface->send($email);
 
         $emailId = $sentEmail->getMessageId();

--- a/src/MessageHandler/SendReceiptEmailHandler.php
+++ b/src/MessageHandler/SendReceiptEmailHandler.php
@@ -52,6 +52,9 @@ class SendReceiptEmailHandler
         $email->htmlTemplate('emails/receipt.html.twig');
         $email->textTemplate('emails/receipt.txt.twig');
 
+        // Ask compliant autoresponders to not reply to this email
+        $email->getHeaders()->addTextHeader('X-Auto-Response-Suppress', 'All');
+
         $sentEmail = $this->transportInterface->send($email);
 
         $message = $ticket->getMessages()->first();

--- a/src/MessageHandler/SendResetPasswordEmailHandler.php
+++ b/src/MessageHandler/SendResetPasswordEmailHandler.php
@@ -58,6 +58,9 @@ class SendResetPasswordEmailHandler
         $email->htmlTemplate('emails/reset_password.html.twig');
         $email->textTemplate('emails/reset_password.txt.twig');
 
+        // Ask compliant autoresponders to not reply to this email
+        $email->getHeaders()->addTextHeader('X-Auto-Response-Suppress', 'All');
+
         $this->transportInterface->send($email);
     }
 }

--- a/tests/Factory/MailboxEmailFactory.php
+++ b/tests/Factory/MailboxEmailFactory.php
@@ -47,6 +47,11 @@ final class MailboxEmailFactory extends PersistentProxyObjectFactory
                 $headers .= "\nIn-Reply-To: <{$attributes['inReplyTo']}>\r";
             }
 
+            $attributesHeaders = $attributes['headers'] ?? [];
+            foreach ($attributesHeaders as $name => $value) {
+                $headers .= "\n{$name}: {$value}\r";
+            }
+
             $rawEmail = "{$headers}\n\r\n\r{$attributes['htmlBody']}";
 
             $clientManager = new PHPIMAP\ClientManager();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/815

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. With Thunderbird, go to the Parameters, General, and at the very bottom "Configuration editor"
2. Search for `mail.compose.other.header` and set the header `Auto-Submitted`
3. Start an email and add the header `Auto-Submitted` with the value `auto-generated` (or at least different than `no`)
4. Send the email to support@example.com with a user that can create tickets
5. Wait for the email collector to collect the emails
6. Verify in the logs that you get a notice message `MailboxEmail #2 ignored: detected as auto reply`

Do the same with the header `X-Autoreply` set to `yes`.

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [ ] Code is manually tested
- [ ] Permissions / authorizations are verified
- [ ] New data can be imported
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works in both light and dark modes
- [ ] Interface works on both Firefox and Chrome
- [ ] Accessibility has been tested
- [ ] Translations are synchronized
- [ ] Tests are up to date
- [ ] Copyright notices are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
