### PR TITLE
fix: Find LDAP user by email if identifier is not set yet

### DIFF
--- a/src/MessageHandler/SynchronizeLdapHandler.php
+++ b/src/MessageHandler/SynchronizeLdapHandler.php
@@ -52,9 +52,16 @@ class SynchronizeLdapHandler
                 'ldapIdentifier' => $ldapUser->getLdapIdentifier(),
             ]);
 
+            if (!$user) {
+                $user = $userRepository->findOneBy([
+                    'email' => $ldapUser->getEmail(),
+                ]);
+            }
+
             if ($user) {
                 $user->setEmail($ldapUser->getEmail());
                 $user->setName($ldapUser->getName());
+                $user->setLdapIdentifier($ldapUser->getLdapIdentifier());
 
                 $errors = $this->validator->validate($user);
                 $errors = ConstraintErrorsFormatter::format($errors);

--- a/src/Security/Authorizer.php
+++ b/src/Security/Authorizer.php
@@ -30,14 +30,19 @@ class Authorizer
     ) {
     }
 
-    public function grant(Entity\User $user, Entity\Role $role, ?Entity\Organization $organization = null): void
-    {
+    public function grant(
+        Entity\User $user,
+        Entity\Role $role,
+        ?Entity\Organization $organization = null,
+        bool $flush = true
+    ): void {
         $authorization = new Entity\Authorization();
-        $authorization->setHolder($user);
         $authorization->setRole($role);
         $authorization->setOrganization($organization);
 
-        $this->authorizationRepository->save($authorization, true);
+        $user->addAuthorization($authorization);
+
+        $this->authorizationRepository->save($authorization, $flush);
     }
 
     public function ungrant(Entity\User $user, Entity\Authorization $authorization): void

--- a/src/Service/UserCreator.php
+++ b/src/Service/UserCreator.php
@@ -50,6 +50,7 @@ class UserCreator
                     $user,
                     $defaultRole,
                     $defaultOrganization,
+                    $flush,
                 );
             }
         }

--- a/tests/MessageHandler/SynchronizeLdapHandlerTest.php
+++ b/tests/MessageHandler/SynchronizeLdapHandlerTest.php
@@ -40,7 +40,7 @@ class SynchronizeLdapHandlerTest extends WebTestCase
         $this->assertSame('Dominique Aragua', $user2->getName());
     }
 
-    public function testInvokeUpdateUsers(): void
+    public function testInvokeUpdateUsersByLdapIdentifier(): void
     {
         $container = static::getContainer();
         /** @var MessageBusInterface */
@@ -49,6 +49,25 @@ class SynchronizeLdapHandlerTest extends WebTestCase
             'email' => 'cgature@example.com',
             'name' => 'C. Gature',
             'ldapIdentifier' => 'charlie',
+        ]);
+
+        $bus->dispatch(new Message\SynchronizeLdap());
+
+        $user->_refresh();
+        $this->assertSame('charlie@example.com', $user->getEmail());
+        $this->assertSame('Charlie Gature', $user->getName());
+        $this->assertSame('charlie', $user->getLdapIdentifier());
+    }
+
+    public function testInvokeUpdateUsersByEmailOtherwise(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+        $user = Factory\UserFactory::createOne([
+            'email' => 'charlie@example.com',
+            'name' => 'C. Gature',
+            'ldapIdentifier' => '',
         ]);
 
         $bus->dispatch(new Message\SynchronizeLdap());


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

- make sure LDAP is enabled (`LDAP_ENABLED=true` should be in your `.env.local` file)
- reset the database without seeds: `make db-reset FORCE=true NO_SEED=true`
- create the user Charlie Gature: `./docker/bin/console app:users:create --email=charlie@example.com --password=secret`
- synchronize the LDAP data: `./docker/bin/console app:ldap:sync`
- verify it doesn't fail
- login with `charlie` / `secret`
- verify that you can login and that the user's LDAP identifier is `charlie` in the admin

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
