### PR TITLE
imp: Set the default value of Contract time accounting unit to 30

### DIFF
--- a/src/Entity/Contract.php
+++ b/src/Entity/Contract.php
@@ -120,7 +120,7 @@ class Contract implements EntityInterface, MonitorableEntityInterface, UidEntity
         $this->maxHours = 10;
         $this->startAt = Utils\Time::now();
         $this->endAt = Utils\Time::relative('last day of december');
-        $this->timeAccountingUnit = 0;
+        $this->timeAccountingUnit = 30;
         $this->notes = '';
         $this->hoursAlert = 0;
         $this->dateAlert = 0;


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a new contract
2. Verify that the default value for the "time accounting unit" is 30

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
