### PR TITLE
fix: Change "assigné" to "attribué" in the French translation

### DIFF
--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -183,7 +183,7 @@ home.all_your_tickets: 'Voir tous vos tickets'
 home.new_ticket: 'Nouveau ticket'
 home.no_tickets: 'Aucun ticket'
 home.title: 'Bienvenue sur Bileto'
-home.your_assigned_tickets: 'Vos tickets assignés'
+home.your_assigned_tickets: 'Vos tickets attribués'
 home.your_tickets: 'Vos tickets'
 hours_formatter.hours.long: "{ hours, plural, one {1\_heure} other {#\_heures} }"
 hours_formatter.hours.short: "{hours}\_h"
@@ -281,7 +281,7 @@ organizations.observers.add_user: 'Ajouter aux observateurs'
 organizations.observers.confirm_add_user: "En ajoutant cet utilisateur aux observateurs de l’organisation, vous lui permettez d’avoir accès à tous les futurs tickets ouverts dans celle-ci. Confirmez-vous\_?"
 organizations.observers.remove_user: 'Retirer des observateurs'
 organizations.responsible_team: 'Équipe responsable'
-organizations.responsible_team.caption: 'L’équipe responsable de l’organisation sera assignée par défaut aux tickets ouverts dans cette organisation.'
+organizations.responsible_team.caption: 'L’équipe responsable de l’organisation sera attribuée par défaut aux tickets ouverts dans cette organisation.'
 organizations.responsible_team.auto: Automatique
 organizations.settings.deletion.confirm: "Êtes-vous sûr de vouloir supprimer cette organisation\_?"
 organizations.settings.deletion.going_delete: "Vous êtes sur le point de supprimer l’organisation «\_{organization}\_». Cela supprimera également les tickets et contrats associés."
@@ -388,7 +388,7 @@ teams.index.new_team: 'Nouvelle équipe'
 teams.index.none: 'Aucune équipe'
 teams.index.number: '{count, plural, =0 {Aucune équipe} one {1 équipe} other {# équipes}}'
 teams.index.title: 'Équipes & Agents'
-teams.is_responsible: 'Équipe responsable (peut être automatiquement assignée à un ticket)'
+teams.is_responsible: 'Équipe responsable (peut être automatiquement attribuée à un ticket)'
 teams.name: Nom
 teams.new.submit: 'Créer l’équipe'
 teams.new.title: 'Nouvelle équipe'
@@ -463,7 +463,7 @@ tickets.index.tickets: Tickets
 tickets.index.title: Tickets
 tickets.index.title.all: 'Tous les tickets'
 tickets.index.title.to_assign: 'Tickets à attribuer'
-tickets.index.title.your_assigned_tickets: 'Vos tickets assignés'
+tickets.index.title.your_assigned_tickets: 'Vos tickets attribués'
 tickets.index.title.your_tickets: 'Vos tickets'
 tickets.index.views.title: 'Vos vues'
 tickets.involves: Concerne


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Verify on the home page and in the tickets lists that "Vos tickets assignés" has been changed to "Vos tickets attribués"
2. Verify on the organization settings page and in the team form that "équipe assignée" has been changed to "équipe attribuée"

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [ ] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
