### PR TITLE
fix: Fix display of total spent time when equal to 0 in French

### DIFF
--- a/src/Twig/HoursFormatterExtension.php
+++ b/src/Twig/HoursFormatterExtension.php
@@ -60,7 +60,7 @@ class HoursFormatterExtension extends AbstractExtension
     private function format(int $hours, int $minutes, string $format = 'short'): string
     {
         if ($format === 'long') {
-            if ($minutes === 0) {
+            if ($minutes === 0 && $hours !== 0) {
                 return $this->translator->trans('hours_formatter.hours.long', [
                     'hours' => $hours,
                 ]);
@@ -75,7 +75,7 @@ class HoursFormatterExtension extends AbstractExtension
                 ]);
             }
         } else {
-            if ($minutes === 0) {
+            if ($minutes === 0 && $hours !== 0) {
                 return $this->translator->trans('hours_formatter.hours.short', [
                     'hours' => $hours,
                 ]);

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -104,7 +104,7 @@ contracts.alerts.edit.date_alert.before: 'Alerter à'
 contracts.alerts.edit.hours_alert.after: '% des heures seront consommées.'
 contracts.alerts.edit.hours_alert.before: 'Alerter lorsque'
 contracts.alerts.edit.title: 'Configurer les alertes du contrat'
-contracts.days_consumed: "<strong>{days, plural, =0 {0\_j consommé} one {1\_j consommé} other {#\_j consommés}}</strong>"
+contracts.days_consumed: "<strong>{days, plural, one {#\_j consommé} other {#\_j consommés}}</strong>"
 contracts.edit.title: 'Modifier un contrat'
 contracts.form.associate_tickets: 'Associer les tickets existants créés durant la période du contrat'
 contracts.form.associate_unaccounted_times: 'Associer les temps passés existants non comptabilisés'
@@ -127,7 +127,7 @@ contracts.new.title: 'Nouveau contrat'
 contracts.notes: 'Notes privées'
 contracts.show.alert: Alerte
 contracts.show.alert.before_end: '{days} jours<br>avant la fin'
-contracts.show.time_accounting_unit: "Unité de comptabilisation du temps\_: {count, plural, one {1 minute} other {# minutes}}"
+contracts.show.time_accounting_unit: "Unité de comptabilisation du temps\_: {count, plural, one {# minute} other {# minutes}}"
 contracts.show.edit: 'Modifier le contrat'
 contracts.show.notes_confidential: Confidentielles
 contracts.show.renew: Renouveler
@@ -187,11 +187,11 @@ home.no_tickets: 'Aucun ticket'
 home.title: 'Bienvenue sur Bileto'
 home.your_assigned_tickets: 'Vos tickets attribués'
 home.your_tickets: 'Vos tickets'
-hours_formatter.hours.long: "{ hours, plural, one {1\_heure} other {#\_heures} }"
+hours_formatter.hours.long: "{ hours, plural, one {#\_heure} other {#\_heures} }"
 hours_formatter.hours.short: "{hours}\_h"
-hours_formatter.hours_and_minutes.long: "{ hours, plural, one {1\_heure} other {#\_heures} }\_{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.hours_and_minutes.long: "{ hours, plural, one {#\_heure} other {#\_heures} }\_{ minutes, plural, one {#\_minute} other {#\_minutes} }"
 hours_formatter.hours_and_minutes.short: "{hours}\_h\_{minutes}\_m"
-hours_formatter.minutes.long: "{ minutes, plural, one {1\_minute} other {#\_minutes} }"
+hours_formatter.minutes.long: "{ minutes, plural, one {#\_minute} other {#\_minutes} }"
 hours_formatter.minutes.short: "{minutes}\_m"
 labels.color: Couleur
 labels.deletion.confirm: "Êtes-vous sûr de vouloir supprimer cette étiquette\_?"


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Set the interface in French
1. Open a ticket with a user who can see both accounted and real spent time
2. Verify the ticket has no spent time
3. Verify that the total time is "0 minute"

## Checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
