### PR TITLE
fix: Stay in organization when changing contracts order

### DIFF
--- a/templates/organizations/contracts/index.html.twig
+++ b/templates/organizations/contracts/index.html.twig
@@ -55,7 +55,7 @@
                         {{ include(
                             'contracts/_sort_button.html.twig',
                             {
-                                currentPath: path('contracts', { q: query }),
+                                currentPath: path('organization contracts', { uid: organization.uid, q: query }),
                                 currentSort: sort,
                             },
                             with_context = false


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Go to the list of contracts of an organization
2. Change their order with the "sort" button
3. Verify you're still in the list of contracts of the organization

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
