### PR TITLE
imp: Send the receipt only if the requester created the ticket

### DIFF
--- a/src/MessageHandler/SendReceiptEmailHandler.php
+++ b/src/MessageHandler/SendReceiptEmailHandler.php
@@ -37,7 +37,17 @@ class SendReceiptEmailHandler
             return;
         }
 
+        $createdBy = $ticket->getCreatedBy();
         $requester = $ticket->getRequester();
+
+        if ($createdBy->getUid() !== $requester->getUid()) {
+            // In this case, the requester already receives the "message"
+            // notification, so we don't need to send the receipt email too.
+            $this->logger->notice(
+                "Receipt email of ticket {$ticketId} has not been sent as the requester did not created the ticket."
+            );
+            return;
+        }
 
         $locale = $requester->getLocale();
         $subject = $this->translator->trans('emails.receipt.subject', locale: $locale);

--- a/tests/Controller/Organizations/TicketsControllerTest.php
+++ b/tests/Controller/Organizations/TicketsControllerTest.php
@@ -218,13 +218,12 @@ class TicketsControllerTest extends WebTestCase
         Utils\Time::freeze($now);
         $client = static::createClient();
         list(
-            $user,
             $requester,
             $observer,
-        ) = Factory\UserFactory::createMany(3);
-        $client->loginUser($user->_real());
+        ) = Factory\UserFactory::createMany(2);
+        $client->loginUser($requester->_real());
         $organization = Factory\OrganizationFactory::createOne();
-        $this->grantOrga($user->_real(), [
+        $this->grantOrga($requester->_real(), [
             'orga:create:tickets',
             'orga:update:tickets:status',
             'orga:update:tickets:type',
@@ -266,7 +265,7 @@ class TicketsControllerTest extends WebTestCase
         $this->assertSame($title, $ticket->getTitle());
         $this->assertSame(20, strlen($ticket->getUid()));
         $this->assertEquals($now, $ticket->getCreatedAt());
-        $this->assertSame($user->getId(), $ticket->getCreatedBy()->getId());
+        $this->assertSame($requester->getId(), $ticket->getCreatedBy()->getId());
         $this->assertSame('incident', $ticket->getType());
         $this->assertSame('new', $ticket->getStatus());
         $this->assertSame('high', $ticket->getUrgency());
@@ -282,7 +281,7 @@ class TicketsControllerTest extends WebTestCase
         $message = Factory\MessageFactory::last();
         $this->assertSame($messageContent, $message->getContent());
         $this->assertEquals($now, $message->getCreatedAt());
-        $this->assertSame($user->getId(), $message->getCreatedBy()->getId());
+        $this->assertSame($requester->getId(), $message->getCreatedBy()->getId());
         $this->assertSame($ticket->getId(), $message->getTicket()->getId());
         $this->assertFalse($message->isConfidential());
         $this->assertSame('webapp', $message->getVia());


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/905

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a ticket and set a requester different than the current user
2. Verify that the requester gets only the "message" notification

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
