### PR TITLE
tec: Allow administrators to send PII to Sentry

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,8 @@ MAILER_FROM=support@example.com
 
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 
+SENTRY_SEND_DEFAULT_PII=false
+
 LDAP_ENABLED=false
 LDAP_HOST="ldap"
 LDAP_PORT=1389

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -9,3 +9,4 @@ when@prod:
         register_error_handler: false
         options:
             release: '%app.version%'
+            send_default_pii: '%env(bool:SENTRY_SEND_DEFAULT_PII)%'

--- a/docs/administrators/deploy.md
+++ b/docs/administrators/deploy.md
@@ -304,6 +304,13 @@ www-data$ php bin/console app:ldap:sync
 You can configure Bileto to send errors (exceptions and logs) to a Sentry server.
 All you need to do is set the `SENTRY_DSN` environment variable to the value that Sentry gives you when you create a new project.
 
+You can also set `SENTRY_SEND_DEFAULT_PII` to `true` to send personally identifiable information (PII) to Sentry (e.g. IP, logged-in user's email, etc.).
+
+> [!CAUTION]
+> Sending PII to Sentry is subject to GDPR.
+> Don't enable this option unless you're sure you're compliant.
+> More information about collected data in [the Sentry documentation](https://docs.sentry.io/platforms/php/guides/symfony/data-management/data-collected/).
+
 ## Updating the production environment
 
 **Please always start by checking the migration notes in [the changelog](/CHANGELOG.md) before updating Bileto.**

--- a/env.sample
+++ b/env.sample
@@ -58,6 +58,12 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 # Uncomment and set with the DSN provided by your Sentry project.
 # SENTRY_DSN="https://5fe4d21cda80b563b4557707c12eb30@sentry.example.com/42"
 
+# Uncomment to send personally identifiable information (PPI) to Sentry.
+# This data is subject to GDPR, so don't enable this option unless you're
+# sure you're compliant.
+# More info about collected data: https://docs.sentry.io/platforms/php/guides/symfony/data-management/data-collected/
+# SENTRY_SEND_DEFAULT_PII=true
+
 #########################
 # Configuration of LDAP #
 #########################


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/915

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a Sentry project
2. Setup Sentry locally and set `SENTRY_SEND_DEFAULT_PII=true`
3. Set the environment to `prod` and run `./docker/bin/console c:c`
4. Generate an error (e.g. 404 error)
5. Verify that the error appears in Sentry and that it contains IP, username, etc.

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
