### PR TITLE
imp: Allow to select the organization when opening a ticket from the global list

### DIFF
--- a/templates/tickets/index.html.twig
+++ b/templates/tickets/index.html.twig
@@ -81,14 +81,27 @@
                         ) }}
                     </div>
 
-                    {% if defaultOrganization %}
-                        <a
-                            class="button button--primary button--uppercase"
-                            href="{{ path('new organization ticket', { uid: defaultOrganization.uid }) }}"
-                        >
-                            {{ icon('plus') }}
-                            {{ 'tickets.index.new_ticket' | trans }}
-                        </a>
+                    {% if is_granted('orga:create:tickets', 'any') %}
+                        {% if mustSelectOrganization %}
+                            <button
+                                class="button button--primary button--uppercase"
+                                type="button"
+                                data-controller="modal-opener"
+                                data-action="modal-opener#fetch"
+                                data-modal-opener-href-value="{{ path('new ticket') }}"
+                            >
+                                {{ icon('plus') }}
+                                {{ 'tickets.index.new_ticket' | trans }}
+                            </button>
+                        {% else %}
+                            <a
+                                class="button button--primary button--uppercase"
+                                href="{{ path('new organization ticket', { uid: defaultOrganization.uid }) }}"
+                            >
+                                {{ icon('plus') }}
+                                {{ 'tickets.index.new_ticket' | trans }}
+                            </a>
+                        {% endif %}
                     {% endif %}
                 </div>
 

--- a/templates/tickets/new.html.twig
+++ b/templates/tickets/new.html.twig
@@ -1,0 +1,13 @@
+{#
+ # This file is part of Bileto.
+ # Copyright 2022-2025 Probesys
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ #}
+
+{% extends 'modal.html.twig' %}
+
+{% block title %}{{ 'tickets.new.title' | trans }}{% endblock %}
+
+{% block body %}
+    {{ form(form, { action: path('new ticket') }) }}
+{% endblock %}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -489,6 +489,7 @@ tickets.list.request_opened_on: 'Request opened on <time datetime="{dateIso}">{d
 tickets.list.request_updated_on: 'Request updated on <time datetime="{dateIso}">{date}</time>'
 tickets.list.time_spent: '{ count } spent'
 tickets.list.time_spent.unaccounted: '{ count } unaccounted'
+tickets.new.open_ticket: 'Open a ticket'
 tickets.new.submit: 'Create the ticket'
 tickets.new.title: 'New ticket'
 tickets.observers: Observers

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -489,6 +489,7 @@ tickets.list.request_opened_on: 'Demande ouverte le <time datetime="{dateIso}">{
 tickets.list.request_updated_on: 'Demande mise à jour le <time datetime="{dateIso}">{date}</time>'
 tickets.list.time_spent: '{ count } passée(s)'
 tickets.list.time_spent.unaccounted: '{ count } non comptabilisée(s)'
+tickets.new.open_ticket: 'Ouvrir un ticket'
 tickets.new.submit: 'Créer le ticket'
 tickets.new.title: 'Nouveau ticket'
 tickets.observers: Observateurs


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/924

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create two users: one must be able to open tickets in several organizations, the other must be able to open tickets in only one organization
2. With the first user, go to the global tickets list and click on "New ticket"
3. Verify that a modal allows to select the organization
4. With the other user, go to the global tickets list and click on "New ticket"
5. Verify that you're redirected to the "new ticket" form of the user's default organization

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
