### PR TITLE
imp: Change quick search so it searches for tickets with any label

### DIFF
--- a/src/SearchEngine/Ticket/QuickSearchFilter.php
+++ b/src/SearchEngine/Ticket/QuickSearchFilter.php
@@ -220,16 +220,12 @@ class QuickSearchFilter
         return $this->labels;
     }
 
-    public function addLabel(Entity\Label $label): void
+    /**
+     * @param Collections\Collection<int, Entity\Label> $values
+     */
+    public function setLabels(Collections\Collection $values): void
     {
-        if (!$this->labels->contains($label)) {
-            $this->labels->add($label);
-        }
-    }
-
-    public function removeLabel(Entity\Label $label): void
-    {
-        $this->labels->removeElement($label);
+        $this->labels = $values;
     }
 
     /**
@@ -328,17 +324,9 @@ class QuickSearchFilter
             $textualQueryParts[] = "team:{$values}";
         }
 
-        foreach ($this->labels as $label) {
-            $value = $label->getName();
-
-            if (
-                str_contains($value, ' ') &&
-                (!str_starts_with($value, '"') || !str_ends_with($value, '"'))
-            ) {
-                $value = '"' . $value . '"';
-            }
-
-            $textualQueryParts[] = "label:{$value}";
+        if (!$this->labels->isEmpty()) {
+            $values = $this->processLabelValues($this->labels);
+            $textualQueryParts[] = "label:{$values}";
         }
 
         if ($this->priorities) {
@@ -385,5 +373,26 @@ class QuickSearchFilter
         }, $teams->toArray());
 
         return implode(',', $teamIds);
+    }
+
+    /**
+     * @param Collections\Collection<int, Entity\Label> $labels
+     */
+    private function processLabelValues(Collections\Collection $labels): string
+    {
+        $labelNames = array_map(function (Entity\Label $label): string {
+            $value = $label->getName();
+
+            if (
+                str_contains($value, ' ') &&
+                (!str_starts_with($value, '"') || !str_ends_with($value, '"'))
+            ) {
+                $value = '"' . $value . '"';
+            }
+
+            return $value;
+        }, $labels->toArray());
+
+        return implode(',', $labelNames);
     }
 }

--- a/src/SearchEngine/Ticket/QuickSearchFilterBuilder.php
+++ b/src/SearchEngine/Ticket/QuickSearchFilterBuilder.php
@@ -57,7 +57,7 @@ class QuickSearchFilterBuilder
                 $qualifier = $condition->getQualifier();
                 $value = $condition->getValue();
 
-                if ($qualifier !== 'label' && isset($qualifiersAlreadySet[$qualifier])) {
+                if (isset($qualifiersAlreadySet[$qualifier])) {
                     return null;
                 }
 
@@ -90,13 +90,8 @@ class QuickSearchFilterBuilder
                     $teams = $this->processTeams($values);
                     $quickSearchFilter->setTeams($teams);
                 } elseif ($qualifier === 'label') {
-                    foreach ($values as $value) {
-                        $labels = $this->labelRepository->findByName($value);
-
-                        foreach ($labels as $label) {
-                            $quickSearchFilter->addLabel($label);
-                        }
-                    }
+                    $labels = $this->processLabels($values);
+                    $quickSearchFilter->setLabels($labels);
                 } elseif ($qualifier === 'type' && count($values) === 1) {
                     $quickSearchFilter->setType($values[0]);
                 } elseif ($qualifier === 'no' && $values[0] === 'assignee') {
@@ -161,5 +156,28 @@ class QuickSearchFilterBuilder
         ]);
 
         return new Collections\ArrayCollection($teams);
+    }
+
+    /**
+     * @param string[] $values
+     *
+     * @return Collections\ArrayCollection<int, Entity\Label>
+     */
+    private function processLabels(array $values): Collections\ArrayCollection
+    {
+        /** @var Collections\ArrayCollection<int, Entity\Label> */
+        $labels = new Collections\ArrayCollection();
+
+        foreach ($values as $value) {
+            $matchingLabels = $this->labelRepository->findByName($value);
+
+            foreach ($matchingLabels as $label) {
+                if (!$labels->contains($label)) {
+                    $labels->add($label);
+                }
+            }
+        }
+
+        return $labels;
     }
 }

--- a/tests/Controller/Tickets/QuickSearchesControllerTest.php
+++ b/tests/Controller/Tickets/QuickSearchesControllerTest.php
@@ -108,7 +108,7 @@ class QuickSearchesControllerTest extends WebTestCase
             ],
         ]);
 
-        $expectedQuery = urlencode('label:bar label:foo');
+        $expectedQuery = urlencode('label:bar,foo');
         $this->assertResponseRedirects("/tickets?q={$expectedQuery}", 302);
     }
 

--- a/tests/SearchEngine/Ticket/QuickSearchFilterBuilderTest.php
+++ b/tests/SearchEngine/Ticket/QuickSearchFilterBuilderTest.php
@@ -180,7 +180,7 @@ class QuickSearchFilterBuilderTest extends WebTestCase
         $this->assertSame(['high'], $ticketQuickSearchFilter->getPriorities());
     }
 
-    public function testGetFilterWithLabelConditionsReturnsFilter(): void
+    public function testGetFilterWithLabelConditionReturnsFilter(): void
     {
         $fooLabel = Factory\LabelFactory::createOne([
             'name' => 'foo',
@@ -191,7 +191,7 @@ class QuickSearchFilterBuilderTest extends WebTestCase
         $bazLabel = Factory\LabelFactory::createOne([
             'name' => 'BAZ',
         ]);
-        $query = SearchEngine\Query::fromString('label:foo label:baz');
+        $query = SearchEngine\Query::fromString('label:foo,baz');
 
         $ticketQuickSearchFilter = $this->ticketQuickSearchFilterBuilder->getFilter($query);
 
@@ -368,12 +368,12 @@ class QuickSearchFilterBuilderTest extends WebTestCase
         Factory\LabelFactory::createOne([
             'name' => 'Bar Baz',
         ]);
-        $query = SearchEngine\Query::fromString('label:foo label:"bar baz"');
+        $query = SearchEngine\Query::fromString('label:foo,"bar baz"');
         $ticketQuickSearchFilter = $this->ticketQuickSearchFilterBuilder->getFilter($query);
 
         $textualQuery = $ticketQuickSearchFilter->toTextualQuery();
 
-        $this->assertSame('label:foo label:"Bar Baz"', $textualQuery);
+        $this->assertSame('label:foo,"Bar Baz"', $textualQuery);
     }
 
     public function testSetText(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/issues/834

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create two labels
2. Set one label on a first ticket and both labels to another ticket
3. In the "quick search form", search for both labels
4. Verify that it returns the two tickets

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
