### PR TITLE
removed double validation on the message's content, added a scroll be…

### DIFF
--- a/src/Form/AnswerForm.php
+++ b/src/Form/AnswerForm.php
@@ -96,11 +96,6 @@ class AnswerForm extends AbstractType
                 'sanitize_html' => true,
                 'sanitizer' => 'app.message_sanitizer',
                 'block_prefix' => 'editor',
-                'constraints' => [
-                    new Assert\NotBlank(
-                        message: new TranslatableMessage('message.content.required', [], 'errors'),
-                    ),
-                ],
             ]);
 
             $canPostSolutionApprovement = $ticketIsResolved && $ticketHasSolution;


### PR DESCRIPTION
…havior to the ticket show page so that it scroll down to answer form when form is not valid

## Related issue(s)

https://github.com/Probesys/bileto/issues/823

## How to test manually

- Go to an open ticket
- Try to post an answer without writing anything (you can select time spent it doesnt change anything)
- It should scroll you down to the form with the error message
- If you quit the ticket and go back it shouldnt scroll you down

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
