### PR TITLE
Use the email's date as message's creation date

### DIFF
--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -175,6 +175,7 @@ class CreateTicketsFromMailboxEmailsHandler
         $messageContent = $this->appMessageSanitizer->sanitize($messageContent);
 
         $message = new Message();
+        $message->setCreatedAt($mailboxEmail->getDate());
         $message->setContent($messageContent);
         $message->setTicket($ticket);
         $message->setIsConfidential(false);

--- a/src/Utils/Time.php
+++ b/src/Utils/Time.php
@@ -48,9 +48,15 @@ class Time
         return self::relative("-{$number} {$unit}");
     }
 
-    public static function freeze(\DateTimeImmutable $datetime): void
+    public static function freeze(?\DateTimeImmutable $datetime = null): \DateTimeImmutable
     {
+        if ($datetime === null) {
+            $datetime = self::now();
+        }
+
         self::$freezedNow = $datetime;
+
+        return self::$freezedNow;
     }
 
     public static function unfreeze(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Stop the worker
2. Send an email to support
3. Wait for more than a minute
4. Collect the emails manually
5. Verify that the ticket is created at "now", but the first message's date is the email's date

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
