### PR TITLE
fix: Fix transfer event when an organization has been deleted

### DIFF
--- a/src/Twig/TicketEventChangesFormatterExtension.php
+++ b/src/Twig/TicketEventChangesFormatterExtension.php
@@ -468,10 +468,20 @@ class TicketEventChangesFormatterExtension
     private function formatOrganizationChanges(?Entity\User $user, array $changes): string
     {
         $username = $this->formatUserName($user);
+
         $oldOrganization = $this->organizationRepository->find($changes[0]);
-        $oldOrganizationName = $this->escape($oldOrganization->getName());
+        if ($oldOrganization) {
+            $oldOrganizationName = $this->escape($oldOrganization->getName());
+        } else {
+            $oldOrganizationName = $this->translator->trans('tickets.events.organization.deleted');
+        }
+
         $newOrganization = $this->organizationRepository->find($changes[1]);
-        $newOrganizationName = $this->escape($newOrganization->getName());
+        if ($newOrganization) {
+            $newOrganizationName = $this->escape($newOrganization->getName());
+        } else {
+            $newOrganizationName = $this->translator->trans('tickets.events.organization.deleted');
+        }
 
         return $this->translator->trans(
             'tickets.events.organization',

--- a/tests/Twig/TicketEventChangesFormatterExtensionTest.php
+++ b/tests/Twig/TicketEventChangesFormatterExtensionTest.php
@@ -285,4 +285,25 @@ class TicketEventChangesFormatterExtensionTest extends WebTestCase
         $message = strip_tags($message);
         $this->assertStringContainsString("transferred the ticket from Foo to Bar", $message);
     }
+
+    public function testFormatTicketHandlesDeletedOrganizationsChanged(): void
+    {
+        $oldOrganization = OrganizationFactory::createOne([
+            'name' => 'Foo',
+        ]);
+        $newOrganization = OrganizationFactory::createOne([
+            'name' => 'Bar',
+        ]);
+        $ticket = TicketFactory::createOne([
+            'organization' => $oldOrganization,
+        ]);
+        $ticket->setOrganization($newOrganization->_real());
+        $event = $this->saveEvent($ticket);
+        $oldOrganization->_delete();
+
+        $message = $this->formatter->formatTicketChanges($event, 'organization');
+
+        $message = strip_tags($message);
+        $this->assertStringContainsString("transferred the ticket from deleted organization to Bar", $message);
+    }
 }

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -456,6 +456,7 @@ tickets.events.observers.added: '<strong>{username}</strong> added <i>{added}</i
 tickets.events.observers.added_and_removed: '<strong>{username}</strong> added {added}</i> and removed <i>{removed}</i> from observers'
 tickets.events.observers.removed: '<strong>{username}</strong> removed <i>{removed}</i> from observers'
 tickets.events.organization: '<strong>{username}</strong> transferred the ticket from <i>{oldValue}</i> to <i>{newValue}</i>'
+tickets.events.organization.deleted: 'deleted organization'
 tickets.events.priority: '<strong>{username}</strong> changed the priority from <i>{oldValue}</i> to <i>{newValue}</i>'
 tickets.events.requester: '<strong>{username}</strong> changed the requester from <i>{oldValue}</i> to <i>{newValue}</i>'
 tickets.events.solution.changed: '<strong>{username}</strong> changed the solution'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -456,6 +456,7 @@ tickets.events.observers.added: '<strong>{username}</strong> a ajouté <i>{added
 tickets.events.observers.added_and_removed: '<strong>{username}</strong> a ajouté <i>{added}</i> et retiré <i>{removed}</i> des observateurs'
 tickets.events.observers.removed: '<strong>{username}</strong> a retiré <i>{removed}</i> des observateurs'
 tickets.events.organization: '<strong>{username}</strong> a transféré le ticket de <i>{oldValue}</i> à <i>{newValue}</i>'
+tickets.events.organization.deleted: 'organisation supprimée'
 tickets.events.priority: '<strong>{username}</strong> a changé la priorité de <i>{oldValue}</i> à <i>{newValue}</i>'
 tickets.events.requester: '<strong>{username}</strong> a changé le demandeur de <i>{oldValue}</i> à <i>{newValue}</i>'
 tickets.events.solution.changed: '<strong>{username}</strong> a changé la solution'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Make sure to have two organizations and one ticket in one of them
2. Transfer the ticket to the other organization, then back to the initial organization
3. Delete the organization that doesn't have the ticket
4. Open the ticket and verify that the ticket has been transferred to and from a "deleted organization"

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
