### PR TITLE
fix: Fix PHP Docker images failing because of missing libc-client-dev

### DIFF
--- a/docker/development/Dockerfile.php
+++ b/docker/development/Dockerfile.php
@@ -2,9 +2,9 @@
 # Copyright 2022-2025 Probesys
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM php:8.2-fpm
+FROM php:8.2-fpm-bookworm
 
-ENV COMPOSER_HOME /tmp
+ENV COMPOSER_HOME="/tmp"
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -11,12 +11,12 @@ COPY assets/ /app/assets
 RUN npm install && npm run build
 
 # Configure the application
-FROM php:8.2-apache
+FROM php:8.2-apache-bookworm
 
 WORKDIR /var/www/html
-ENV APP_ENV prod
-ENV COMPOSER_HOME /tmp
-ENV TZ Europe/Paris
+ENV APP_ENV="prod"
+ENV COMPOSER_HOME="/tmp"
+ENV TZ="Europe/Paris"
 
 CMD ["apache2-foreground"]
 ENTRYPOINT ["sh", "/entrypoint.sh"]


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/bileto/pull/510

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Run `make docker-build` and `make docker-image VERSION=edge`
2. Verify that they work

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
