### PR TITLE
fix: Send email notifications for confidential messages

### DIFF
--- a/src/MessageHandler/SendMessageEmailHandler.php
+++ b/src/MessageHandler/SendMessageEmailHandler.php
@@ -9,6 +9,7 @@ namespace App\MessageHandler;
 use App\Entity;
 use App\Repository;
 use App\Message;
+use App\Security;
 use App\Service;
 use App\Utils;
 use Psr\Log\LoggerInterface;
@@ -30,6 +31,7 @@ class SendMessageEmailHandler
 
     public function __construct(
         private Repository\MessageRepository $messageRepository,
+        private Security\Authorizer $authorizer,
         private Service\MessageDocumentStorage $messageDocumentStorage,
         private TranslatorInterface $translator,
         private TransportInterface $transportInterface,
@@ -47,15 +49,6 @@ class SendMessageEmailHandler
 
         if (!$message) {
             $this->logger->error("Message {$messageId} cannot be found in SendMessageEmailHandler.");
-            return;
-        }
-
-        if ($message->isConfidential()) {
-            // If the message is confidential, it should not be sent to recipients
-            // who don't have the orga:see:tickets:messages:confidential
-            // permission. At the moment, I don't know what's the best solution
-            // to handle that so I've decided to never send the notification in
-            // that case. This will have to be improved in the future.
             return;
         }
 
@@ -84,10 +77,23 @@ class SendMessageEmailHandler
             $recipients[$assignee->getEmail()] = $assignee;
         }
 
-        $recipients = array_filter($recipients, function (?Entity\User $user): bool {
+        $recipients = array_filter($recipients, function (?Entity\User $user) use ($message): bool {
             // Remove the anonymous users from the list of recipients to avoid
             // to send emails to wrong addresses.
-            return $user && !$user->isAnonymized();
+            if (!$user || $user->isAnonymized()) {
+                return false;
+            }
+
+            // If the message is confidential, only send to users with the permission
+            if ($message->isConfidential()) {
+                return $this->authorizer->isGrantedForUser(
+                    $user,
+                    'orga:see:tickets:messages:confidential',
+                    $message->getTicket(),
+                );
+            }
+
+            return true;
         });
 
         if (empty($recipients)) {


### PR DESCRIPTION
Closes #338

Confidential messages now send email notifications to users with the `orga:see:tickets:messages:confidential` permission.

Recipients are filtered using `Authorizer::isGrantedForUser()` when the message is confidential.

## Related issue(s)

https://github.com/Probesys/bileto/issues/338

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [ ] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [ ] Pull request has been reviewed and approved
