### PR TITLE
fix: Fix sending email notifications

### DIFF
--- a/src/MessageHandler/EmailSender.php
+++ b/src/MessageHandler/EmailSender.php
@@ -1,0 +1,49 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2025 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\MessageHandler;
+
+use Symfony\Component\Mime;
+
+trait EmailSender
+{
+    /**
+     * Send an email and returns its Message-ID.
+     *
+     * Note that the returned ID is not necessarily the one that will be set on
+     * the email received by the recipient (as the SMTP server can alter it for
+     * instance). This method does its best to return the correct one though.
+     * It seems to work in most of the cases.
+     */
+    private function sendEmail(Mime\Message $email): string
+    {
+        // Make sure to generate a valid Message-ID as it will serve later as a
+        // fallback.
+        $emailHeaders = $email->getHeaders();
+        if (!$emailHeaders->has('Message-ID')) {
+            $emailHeaders->addIdHeader('Message-ID', $email->generateMessageId());
+        }
+
+        $sentMessage = $this->transportInterface->send($email);
+
+        try {
+            $sentMessageId = $sentMessage->getMessageId();
+
+            // This can fail if the returned Message-ID is invalid. In our
+            // case, the ID was an internal id of our SMTP server which cannot
+            // be used usefully.
+            new Mime\Address($sentMessageId);
+
+            return $sentMessageId;
+        } catch (Mime\Exception\RfcComplianceException $e) {
+            // If the Message-ID header of the sent email was invalid, we
+            // return the ID of the original email.
+            /** @var Mime\Header\IdentificationHeader */
+            $messageIdHeader = $emailHeaders->get('Message-ID');
+            return $messageIdHeader->getId();
+        }
+    }
+}

--- a/src/MessageHandler/SendMessageEmailHandler.php
+++ b/src/MessageHandler/SendMessageEmailHandler.php
@@ -26,6 +26,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AsMessageHandler]
 class SendMessageEmailHandler
 {
+    use EmailSender;
+
     public function __construct(
         private Repository\MessageRepository $messageRepository,
         private Service\MessageDocumentStorage $messageDocumentStorage,
@@ -180,9 +182,8 @@ class SendMessageEmailHandler
 
             $email->to($user->getEmailAddress());
 
-            $sentEmail = $this->transportInterface->send($email);
+            $emailId = $this->sendEmail($email);
 
-            $emailId = $sentEmail->getMessageId();
             $message->addEmailNotificationReference($emailId);
         }
 


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Previously, getting the Message-ID of sent emails wasn't reliable and sometimes returned ids not compliant with RFC 2822. As these ids are used then in the References and In-Reply-To headers of the email notifications concerning the future answers, Symfony failed badly with an exception.

Now, the logic is improved to get the correct Message-ID of the sent emails. We also set References and In-Reply-To headers only with values compliant with the RFC.

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

N/A

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
