### PR TITLE
feat: Allow to search tickets by dates in advanced mode

### DIFF
--- a/src/SearchEngine/QueryBuilder.php
+++ b/src/SearchEngine/QueryBuilder.php
@@ -212,17 +212,94 @@ abstract class QueryBuilder
             $values = [$value];
         }
 
-        $dqlExpression = '';
+        $exprs = [];
 
-        foreach ($values as $value) {
-            // TODO parse value and build DQL condition.
+        foreach ($values as $singleValue) {
+            if (str_contains($singleValue, '..')) {
+                $parts = explode('..', $singleValue, 2);
+                [$start] = $this->parseDateToPeriod($parts[0]);
+                [, $end] = $this->parseDateToPeriod($parts[1]);
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            } elseif (str_starts_with($singleValue, '>=')) {
+                [$start] = $this->parseDateToPeriod(substr($singleValue, 2));
+                $key = $this->registerParameter($start);
+                $exprs[] = "{$field} >= :{$key}";
+            } elseif (str_starts_with($singleValue, '>')) {
+                [, $end] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $key = $this->registerParameter($end);
+                $exprs[] = "{$field} > :{$key}";
+            } elseif (str_starts_with($singleValue, '<=')) {
+                [, $end] = $this->parseDateToPeriod(substr($singleValue, 2));
+                $key = $this->registerParameter($end);
+                $exprs[] = "{$field} <= :{$key}";
+            } elseif (str_starts_with($singleValue, '<')) {
+                [$start] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $key = $this->registerParameter($start);
+                $exprs[] = "{$field} < :{$key}";
+            } elseif (str_starts_with($singleValue, '=')) {
+                [$start, $end] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            } else {
+                [$start, $end] = $this->parseDateToPeriod($singleValue);
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            }
         }
+
+        $where = implode(' OR ', $exprs);
 
         if ($not) {
-            return "NOT ({$dqlExpression})";
+            return "NOT ({$where})";
         } else {
-            return $dqlExpression;
+            return "({$where})";
         }
+    }
+
+    /**
+     * Parse a date string and return a period as an array of two DateTimeImmutable.
+     *
+     * @return array{\DateTimeImmutable, \DateTimeImmutable}
+     */
+    private function parseDateToPeriod(string $date): array
+    {
+        $parts = explode('T', $date, 2);
+        $datePart = $parts[0];
+        $timePart = $parts[1] ?? null;
+
+        $dateComponents = explode('-', $datePart);
+        $year = (int) $dateComponents[0];
+        $month = isset($dateComponents[1]) ? (int) $dateComponents[1] : null;
+        $day = isset($dateComponents[2]) ? (int) $dateComponents[2] : null;
+
+        $hour = null;
+        $minute = null;
+        $second = null;
+
+        if ($timePart !== null) {
+            $timeComponents = explode(':', $timePart);
+            $hour = (int) $timeComponents[0];
+            $minute = isset($timeComponents[1]) ? (int) $timeComponents[1] : null;
+            $second = isset($timeComponents[2]) ? (int) $timeComponents[2] : null;
+        }
+
+        $lastDay = (int) (new \DateTimeImmutable("{$year}-" . ($month ?? 12) . "-01"))->format('t');
+
+        $start = new \DateTimeImmutable(sprintf(
+            '%04d-%02d-%02dT%02d:%02d:%02d',
+            $year, $month ?? 1, $day ?? 1, $hour ?? 0, $minute ?? 0, $second ?? 0
+        ));
+
+        $end = new \DateTimeImmutable(sprintf(
+            '%04d-%02d-%02dT%02d:%02d:%02d',
+            $year, $month ?? 12, $day ?? $lastDay, $hour ?? 23, $minute ?? 59, $second ?? 59
+        ));
+
+        return [$start, $end];
     }
 
     /**

--- a/src/SearchEngine/QueryBuilder.php
+++ b/src/SearchEngine/QueryBuilder.php
@@ -194,6 +194,38 @@ abstract class QueryBuilder
     }
 
     /**
+     * Return an expression that can be used to match date conditions.
+     *
+     * @param literal-string $field
+     * @param non-empty-string|non-empty-string[]|null $value
+     * @return literal-string
+     */
+    protected function buildExprDate(string $field, mixed $value, bool $not): string
+    {
+        if ($value === null) {
+            return $this->buildExpr($field, null, $not);
+        }
+
+        if (is_array($value)) {
+            $values = $value;
+        } else {
+            $values = [$value];
+        }
+
+        $dqlExpression = '';
+
+        foreach ($values as $value) {
+            // TODO parse value and build DQL condition.
+        }
+
+        if ($not) {
+            return "NOT ({$dqlExpression})";
+        } else {
+            return $dqlExpression;
+        }
+    }
+
+    /**
      * Return a DQL sub-query that returns a list of entity ids for which the
      * ids of the many-to-many associations match the given value.
      *

--- a/src/SearchEngine/QueryBuilder.php
+++ b/src/SearchEngine/QueryBuilder.php
@@ -194,6 +194,127 @@ abstract class QueryBuilder
     }
 
     /**
+     * Return an expression that can be used to match date conditions.
+     *
+     * @param literal-string $field
+     * @param non-empty-string|non-empty-string[]|null $value
+     * @return literal-string
+     */
+    protected function buildExprDate(string $field, mixed $value, bool $not): string
+    {
+        if ($value === null) {
+            return $this->buildExpr($field, null, $not);
+        }
+
+        if (is_array($value)) {
+            $values = $value;
+        } else {
+            $values = [$value];
+        }
+
+        $exprs = [];
+
+        foreach ($values as $singleValue) {
+            if (str_contains($singleValue, '..')) {
+                $parts = explode('..', $singleValue, 2);
+                [$start] = $this->parseDateToPeriod($parts[0]);
+                [, $end] = $this->parseDateToPeriod($parts[1]);
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            } elseif (str_starts_with($singleValue, '>=')) {
+                [$start] = $this->parseDateToPeriod(substr($singleValue, 2));
+                $key = $this->registerParameter($start);
+                $exprs[] = "{$field} >= :{$key}";
+            } elseif (str_starts_with($singleValue, '>')) {
+                [, $end] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $key = $this->registerParameter($end);
+                $exprs[] = "{$field} > :{$key}";
+            } elseif (str_starts_with($singleValue, '<=')) {
+                [, $end] = $this->parseDateToPeriod(substr($singleValue, 2));
+                $key = $this->registerParameter($end);
+                $exprs[] = "{$field} <= :{$key}";
+            } elseif (str_starts_with($singleValue, '<')) {
+                [$start] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $key = $this->registerParameter($start);
+                $exprs[] = "{$field} < :{$key}";
+            } elseif (str_starts_with($singleValue, '=')) {
+                [$start, $end] = $this->parseDateToPeriod(substr($singleValue, 1));
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            } else {
+                [$start, $end] = $this->parseDateToPeriod($singleValue);
+                $keyStart = $this->registerParameter($start);
+                $keyEnd = $this->registerParameter($end);
+                $exprs[] = "({$field} >= :{$keyStart} AND {$field} <= :{$keyEnd})";
+            }
+        }
+
+        $where = implode(' OR ', $exprs);
+
+        if ($not) {
+            return "NOT ({$where})";
+        } else {
+            return "({$where})";
+        }
+    }
+
+    /**
+     * Parse a date string and return a period as an array of two DateTimeImmutable.
+     *
+     * @return array{\DateTimeImmutable, \DateTimeImmutable}
+     */
+    private function parseDateToPeriod(string $date): array
+    {
+        $parts = explode('T', $date, 2);
+        $datePart = $parts[0];
+        $timePart = $parts[1] ?? null;
+
+        $dateComponents = explode('-', $datePart);
+        $year = (int) $dateComponents[0];
+        $month = isset($dateComponents[1]) ? (int) $dateComponents[1] : null;
+        $day = isset($dateComponents[2]) ? (int) $dateComponents[2] : null;
+
+        $hour = null;
+        $minute = null;
+        $second = null;
+
+        if ($timePart !== null) {
+            $timeComponents = explode(':', $timePart);
+            $hour = (int) $timeComponents[0];
+            $minute = isset($timeComponents[1]) ? (int) $timeComponents[1] : null;
+            $second = isset($timeComponents[2]) ? (int) $timeComponents[2] : null;
+        }
+
+        // "t" is the number of days in the month, which is equivalent to the
+        // last day of the month.
+        $lastDay = (int) (new \DateTimeImmutable("{$year}-" . ($month ?? 12) . "-01"))->format('t');
+
+        $start = new \DateTimeImmutable(sprintf(
+            '%04d-%02d-%02dT%02d:%02d:%02d',
+            $year,
+            $month ?? 1,
+            $day ?? 1,
+            $hour ?? 0,
+            $minute ?? 0,
+            $second ?? 0,
+        ));
+
+        $end = new \DateTimeImmutable(sprintf(
+            '%04d-%02d-%02dT%02d:%02d:%02d',
+            $year,
+            $month ?? 12,
+            $day ?? $lastDay,
+            $hour ?? 23,
+            $minute ?? 59,
+            $second ?? 59,
+        ));
+
+        return [$start, $end];
+    }
+
+    /**
      * Return a DQL sub-query that returns a list of entity ids for which the
      * ids of the many-to-many associations match the given value.
      *

--- a/src/SearchEngine/Ticket/QueryBuilder.php
+++ b/src/SearchEngine/Ticket/QueryBuilder.php
@@ -60,6 +60,8 @@ class QueryBuilder extends SearchEngine\QueryBuilder
             'priority' => $this->buildPriorityExpr(...),
             'contract' => $this->buildContractExpr(...),
             'label' => $this->buildLabelExpr(...),
+            'date' => $this->buildCreatedAtExpr(...),
+            'update' => $this->buildUpdatedAtExpr(...),
             'no:assignee' => $this->buildNoAssigneeExpr(...),
             'no:team' => $this->buildNoTeamExpr(...),
             'no:solution' => $this->buildNoSolutionExpr(...),
@@ -278,6 +280,22 @@ class QueryBuilder extends SearchEngine\QueryBuilder
         } else {
             return "t.id IN ({$labelsDql})";
         }
+    }
+
+    /**
+     * @return literal-string
+     */
+    protected function buildCreatedAtExpr(SearchEngine\Query\Condition $condition): string
+    {
+        return $this->buildExprDate('t.createdAt', $condition->getValue(), $condition->not());
+    }
+
+    /**
+     * @return literal-string
+     */
+    protected function buildUpdatedAtExpr(SearchEngine\Query\Condition $condition): string
+    {
+        return $this->buildExprDate('t.updatedAt', $condition->getValue(), $condition->not());
     }
 
     /**

--- a/src/SearchEngine/Ticket/QueryBuilder.php
+++ b/src/SearchEngine/Ticket/QueryBuilder.php
@@ -60,6 +60,8 @@ class QueryBuilder extends SearchEngine\QueryBuilder
             'priority' => $this->buildPriorityExpr(...),
             'contract' => $this->buildContractExpr(...),
             'label' => $this->buildLabelExpr(...),
+            'date' => $this->buildDateExpr(...),
+            'lastUpdate' => $this->buildLastUpdateExpr(...),
             'no:assignee' => $this->buildNoAssigneeExpr(...),
             'no:team' => $this->buildNoTeamExpr(...),
             'no:solution' => $this->buildNoSolutionExpr(...),
@@ -278,6 +280,22 @@ class QueryBuilder extends SearchEngine\QueryBuilder
         } else {
             return "t.id IN ({$labelsDql})";
         }
+    }
+
+    /**
+     * @return literal-string
+     */
+    protected function buildDateExpr(SearchEngine\Query\Condition $condition): string
+    {
+        return $this->buildExprDate('t.createdAt', $condition->getValue(), $condition->not());
+    }
+
+    /**
+     * @return literal-string
+     */
+    protected function buildLastUpdateExpr(SearchEngine\Query\Condition $condition): string
+    {
+        return $this->buildExprDate('t.updatedAt', $condition->getValue(), $condition->not());
     }
 
     /**

--- a/templates/pages/advanced_search_syntax/tickets.html.twig
+++ b/templates/pages/advanced_search_syntax/tickets.html.twig
@@ -320,6 +320,41 @@
                     </tbody>
                 </table>
             </div>
+
+            <div class="flow">
+                <h3>{{ 'advanced_search_syntax.tickets.qualifiers.dates.title' | trans }}</h3>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th class="col--size30">{{ 'advanced_search_syntax.example' | trans }}</th>
+                            <th>{{ 'advanced_search_syntax.description' | trans }}</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td><code>date:2026-03-23</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example1' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>date:>=2026-03-23</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example2' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>date:2026-03-23..2026-03-25</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example3' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>update:2026-03-23</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example4' | trans }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="flow">

--- a/templates/pages/advanced_search_syntax/tickets.html.twig
+++ b/templates/pages/advanced_search_syntax/tickets.html.twig
@@ -320,6 +320,41 @@
                     </tbody>
                 </table>
             </div>
+
+            <div class="flow">
+                <h3>{{ 'advanced_search_syntax.tickets.qualifiers.dates.title' | trans }}</h3>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th class="col--size30">{{ 'advanced_search_syntax.example' | trans }}</th>
+                            <th>{{ 'advanced_search_syntax.description' | trans }}</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td><code>date:2026-03-23</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example1' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>date:&gt;=2026-03</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example2' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>date:2026-03-23..2026-03-25</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example3' | trans }}</td>
+                        </tr>
+
+                        <tr>
+                            <td><code>lastUpdate:2026-03-23</code></td>
+                            <td>{{ 'advanced_search_syntax.tickets.qualifiers.dates.example4' | trans }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="flow">

--- a/tests/SearchEngine/Ticket/QueryBuilderTest.php
+++ b/tests/SearchEngine/Ticket/QueryBuilderTest.php
@@ -610,4 +610,131 @@ class QueryBuilderTest extends WebTestCase
 
         $this->ticketQueryBuilder->buildQuery($query);
     }
+
+    public function testBuildQueryWithQualifierDate(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateExplicitEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateAsYear(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-01-01T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-12-31T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateGreaterOrEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:>=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt >= :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateGreater(): void
+    {
+        $query = SearchEngine\Query::fromString('date:>2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt > :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateLessOrEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:<=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt <= :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateLess(): void
+    {
+        $query = SearchEngine\Query::fromString('date:<2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt < :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateRange(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026-03-23..2026-03-25');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-25T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateAsArrayAndNot(): void
+    {
+        $query = SearchEngine\Query::fromString('-date:2026-03-23,>=2026-03-30');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            NOT ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1) OR t.createdAt >= :q0p2)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-30T00:00:00'), $parameters['q0p2']);
+    }
+
+    public function testBuildQueryWithQualifierUpdate(): void
+    {
+        $query = SearchEngine\Query::fromString('update:2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.updatedAt >= :q0p0 AND t.updatedAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
 }

--- a/tests/SearchEngine/Ticket/QueryBuilderTest.php
+++ b/tests/SearchEngine/Ticket/QueryBuilderTest.php
@@ -610,4 +610,131 @@ class QueryBuilderTest extends WebTestCase
 
         $this->ticketQueryBuilder->buildQuery($query);
     }
+
+    public function testBuildQueryWithQualifierDate(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateExplicitEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateAsYear(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-01-01T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-12-31T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateGreaterOrEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:>=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt >= :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateGreater(): void
+    {
+        $query = SearchEngine\Query::fromString('date:>2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt > :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateLessOrEqual(): void
+    {
+        $query = SearchEngine\Query::fromString('date:<=2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt <= :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateLess(): void
+    {
+        $query = SearchEngine\Query::fromString('date:<2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            (t.createdAt < :q0p0)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+    }
+
+    public function testBuildQueryWithQualifierDateRange(): void
+    {
+        $query = SearchEngine\Query::fromString('date:2026-03-23..2026-03-25');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-25T23:59:59'), $parameters['q0p1']);
+    }
+
+    public function testBuildQueryWithQualifierDateAsArrayAndNot(): void
+    {
+        $query = SearchEngine\Query::fromString('-date:2026-03-23,>=2026-03-30');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            NOT ((t.createdAt >= :q0p0 AND t.createdAt <= :q0p1) OR t.createdAt >= :q0p2)
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-30T00:00:00'), $parameters['q0p2']);
+    }
+
+    public function testBuildQueryWithQualifierLastUpdate(): void
+    {
+        $query = SearchEngine\Query::fromString('lastUpdate:2026-03-23');
+
+        list($dql, $parameters) = $this->ticketQueryBuilder->buildQuery($query);
+
+        $this->assertSame(<<<SQL
+            ((t.updatedAt >= :q0p0 AND t.updatedAt <= :q0p1))
+            SQL, $dql);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T00:00:00'), $parameters['q0p0']);
+        $this->assertEquals(new \DateTimeImmutable('2026-03-23T23:59:59'), $parameters['q0p1']);
+    }
 }

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -56,6 +56,11 @@ advanced_search_syntax.tickets.qualifiers.actors.example5: 'Tickets without an a
 advanced_search_syntax.tickets.qualifiers.actors.example6: 'Tickets with an assigned agent'
 advanced_search_syntax.tickets.qualifiers.actors.title: Actors
 advanced_search_syntax.tickets.qualifiers.description: 'Qualifiers are special keywords (e.g. <code>status:</code>) that take a value or a comma-separated list of values. They are used to target a particular property.'
+advanced_search_syntax.tickets.qualifiers.dates.example1: 'Tickets created on March 23, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example2: 'Tickets created on or after March 23, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example3: 'Tickets created between March 23, 2026 and March 25, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example4: 'Tickets last updated on March 23, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.title: Dates
 advanced_search_syntax.tickets.qualifiers.labels.example1: 'Tickets with the label “Bug” (case insensitive)'
 advanced_search_syntax.tickets.qualifiers.labels.example2: 'Tickets with the labels “Bug” and “Tickets topic”'
 advanced_search_syntax.tickets.qualifiers.labels.example3: 'Tickets with the labels “Bug” or “Tickets topic”'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -55,6 +55,11 @@ advanced_search_syntax.tickets.qualifiers.actors.example4: 'Tickets assigned to 
 advanced_search_syntax.tickets.qualifiers.actors.example5: 'Tickets without an assigned agent'
 advanced_search_syntax.tickets.qualifiers.actors.example6: 'Tickets with an assigned agent'
 advanced_search_syntax.tickets.qualifiers.actors.title: Actors
+advanced_search_syntax.tickets.qualifiers.dates.example1: 'Tickets created on March 23, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example2: 'Tickets created on or after March, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example3: 'Tickets created between March 23, 2026 and March 25, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example4: 'Tickets last updated on March 23, 2026'
+advanced_search_syntax.tickets.qualifiers.dates.title: Dates
 advanced_search_syntax.tickets.qualifiers.description: 'Qualifiers are special keywords (e.g. <code>status:</code>) that take a value or a comma-separated list of values. They are used to target a particular property.'
 advanced_search_syntax.tickets.qualifiers.labels.example1: 'Tickets with the label “Bug” (case insensitive)'
 advanced_search_syntax.tickets.qualifiers.labels.example2: 'Tickets with the labels “Bug” and “Tickets topic”'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -56,6 +56,11 @@ advanced_search_syntax.tickets.qualifiers.actors.example5: 'Les tickets n’ayan
 advanced_search_syntax.tickets.qualifiers.actors.example6: 'Les tickets ayant un agent attribué'
 advanced_search_syntax.tickets.qualifiers.actors.title: Acteurs
 advanced_search_syntax.tickets.qualifiers.description: 'Les qualificateurs sont des mots-clés particuliers (ex. <code>status:</code>) qui prennent une valeur ou une liste de valeurs séparées par des virgules. Ils permettent de cibler une propriété en particulier.'
+advanced_search_syntax.tickets.qualifiers.dates.example1: 'Les tickets créés le 23 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example2: 'Les tickets créés le 23 mars 2026 ou après'
+advanced_search_syntax.tickets.qualifiers.dates.example3: 'Les tickets créés entre le 23 mars 2026 et le 25 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example4: 'Les tickets dont la dernière mise à jour est le 23 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.title: Dates
 advanced_search_syntax.tickets.qualifiers.labels.example1: "Les tickets avec l’étiquette «\_Bug\_» (insensible à la casse)"
 advanced_search_syntax.tickets.qualifiers.labels.example2: "Les tickets avec les étiquettes «\_Bug\_» et «\_Tickets topic\_»"
 advanced_search_syntax.tickets.qualifiers.labels.example3: "Les tickets avec les étiquettes «\_Bug\_» ou «\_Tickets topic\_»"

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -55,6 +55,11 @@ advanced_search_syntax.tickets.qualifiers.actors.example4: "Les tickets attribu�
 advanced_search_syntax.tickets.qualifiers.actors.example5: 'Les tickets n’ayant pas d’agent attribué'
 advanced_search_syntax.tickets.qualifiers.actors.example6: 'Les tickets ayant un agent attribué'
 advanced_search_syntax.tickets.qualifiers.actors.title: Acteurs
+advanced_search_syntax.tickets.qualifiers.dates.example1: 'Les tickets créés le 23 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example2: 'Les tickets créés en mars 2026 ou après'
+advanced_search_syntax.tickets.qualifiers.dates.example3: 'Les tickets créés entre le 23 mars 2026 et le 25 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.example4: 'Les tickets dont la dernière mise à jour est le 23 mars 2026'
+advanced_search_syntax.tickets.qualifiers.dates.title: Dates
 advanced_search_syntax.tickets.qualifiers.description: 'Les qualificateurs sont des mots-clés particuliers (ex. <code>status:</code>) qui prennent une valeur ou une liste de valeurs séparées par des virgules. Ils permettent de cibler une propriété en particulier.'
 advanced_search_syntax.tickets.qualifiers.labels.example1: "Les tickets avec l’étiquette «\_Bug\_» (insensible à la casse)"
 advanced_search_syntax.tickets.qualifiers.labels.example2: "Les tickets avec les étiquettes «\_Bug\_» et «\_Tickets topic\_»"


### PR DESCRIPTION
## Related issue(s)

Closes #301

## How to test manually

1. Go to the tickets list page :
2. Switch to the advanced search mode by clicking on the search icon
3. Try the following queries and check that the results are correctly filtered:
   - `date:2026-03-23` — tickets created on March 23, 2026
   - `date:2026` — tickets created in 2026
   - `date:>=2026-03-23` — tickets created on or after March 23, 2026
   - `date:>2026-03-23` — tickets created after March 23, 2026
   - `date:<=2026-03-23` — tickets created on or before March 23, 2026
   - `date:<2026-03-23` — tickets created before March 23, 2026
   - `date:2026-03-23..2026-03-25` — tickets created between two dates
   - `date:2026-03-23,>=2026-03-30` — tickets matching either date condition
   - `-date:2026-03-23` — tickets NOT created on March 23, 2026
   - `update:2026-03-23` — tickets last updated on March 23, 2026
4. Click on "Show syntax help" and verify that the new "Dates" section is displayed with examples

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn't applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->
- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved