### PR TITLE
feat: Warn on created organization without access

### DIFF
--- a/src/Controller/OrganizationsController.php
+++ b/src/Controller/OrganizationsController.php
@@ -56,6 +56,12 @@ class OrganizationsController extends BaseController
             $organization->normalizeDomains();
             $this->organizationRepository->save($organization, true);
 
+            if ($this->authorizer->isGranted('orga:see', $organization)) {
+                $this->addFlash('success', new TranslatableMessage('organizations.new.created'));
+            } else {
+                $this->addFlash('success', new TranslatableMessage('organizations.new.created_no_access'));
+            }
+
             if ($this->authorizer->isGranted('orga:manage:contracts', $organization)) {
                 return $this->redirectToRoute('new organization contract', [
                     'uid' => $organization->getUid(),

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -322,6 +322,8 @@ organizations.index.none: 'No organizations'
 organizations.index.number: '{count, plural, =0 {No organizations} one {1 organization} other {# organizations}}'
 organizations.index.title: Organizations
 organizations.name: Name
+organizations.new.created: 'The organization has been created.'
+organizations.new.created_no_access: 'The organization has been created but you’re not authorized to access it.'
 organizations.new.submit: 'Create the organization'
 organizations.new.title: 'New organization'
 organizations.observers.add_user: 'Add to observers'

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -330,6 +330,8 @@ organizations.index.none: 'No organizations'
 organizations.index.number: '{count, plural, =0 {No organizations} one {1 organization} other {# organizations}}'
 organizations.index.title: Organizations
 organizations.name: Name
+organizations.new.created: 'The organization has been created.'
+organizations.new.created_no_access: 'The organization has been created but you’re not authorized to access it.'
 organizations.new.submit: 'Create the organization'
 organizations.new.title: 'New organization'
 organizations.observers.add_user: 'Add to observers'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -322,6 +322,8 @@ organizations.index.none: 'Aucune organisation'
 organizations.index.number: '{count, plural, =0 {Aucune organisation} one {1 organisation} other {# organisations}}'
 organizations.index.title: Organisations
 organizations.name: Nom
+organizations.new.created: 'L’organisation a été créée.'
+organizations.new.created_no_access: 'L’organisation a été créée mais vous n’êtes pas autorisé à y accéder.'
 organizations.new.submit: 'Créer l’organisation'
 organizations.new.title: 'Nouvelle organisation'
 organizations.observers.add_user: 'Ajouter aux observateurs'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -330,6 +330,8 @@ organizations.index.none: 'Aucune organisation'
 organizations.index.number: '{count, plural, =0 {Aucune organisation} one {1 organisation} other {# organisations}}'
 organizations.index.title: Organisations
 organizations.name: Nom
+organizations.new.created: 'L’organisation a été créée.'
+organizations.new.created_no_access: 'L’organisation a été créée mais vous n’êtes pas autorisé à y accéder.'
 organizations.new.submit: 'Créer l’organisation'
 organizations.new.title: 'Nouvelle organisation'
 organizations.observers.add_user: 'Ajouter aux observateurs'


### PR DESCRIPTION
## Related issue(s)

Closes  #730

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->
## How to test manually

1. Log in with a super-admin user (full access to all organizations)
2. Go to "/organizations/new"
3. Create an organization (e.g. "Test with access")
4. Expected: a success flash appears with the message "The organization has been created." (or "L'organisation a été créée." in French), and you're redirected either to the new contract form or to the organizations list
5. Log out and log in with an admin user having only the "admin:create:organizations" permission (no global authorization, no "orga:see" anywhere)
   - If needed, create a dedicated admin role with only "Créer les organisations" checked, then assign it to a test user
6. Go to "/organizations/new"
7. Create another organization (e.g. "Test no access")
8. Expected: a success flash appears with the message "The organization has been created but you're not authorized to access it." (or "L'organisation a été créée mais vous n'êtes pas autorisé à y accéder." in French), and you're redirected to "/organizations"
9. Expected: the newly created organization does not appear in the list.

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
