### PR TITLE
feat: Suggest to act on inactive users

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ APP_ENV="dev"
 APP_SECRET="change-me"
 APP_BASE_URL=""
 APP_DEFAULT_LOCALE="en_GB"
+APP_USERS_INACTIVITY_TIME=12
 
 #################################
 # Configuration of the database #

--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ APP_SECRET="change-me"
 APP_BASE_URL=""
 APP_DEFAULT_LOCALE="en_GB"
 APP_USERS_INACTIVITY_TIME=12
+APP_USERS_INACTIVITY_AUTO="none"
 
 #################################
 # Configuration of the database #

--- a/docs/developers/clean-data.md
+++ b/docs/developers/clean-data.md
@@ -3,4 +3,27 @@
 Some data may expire and need to be cleaned periodically.
 This is the purpose of [the `CleanDataHandler`](/src/MessageHandler/CleanDataHandler.php).
 
-Actually, it only cleans the expired tokens.
+It performs the following operations:
+
+- Delete expired tokens.
+- Delete session logs older than 6 months.
+- Delete entity events related to deleted entities, older than 1 week.
+- Anonymize or delete inactive users.
+
+## Inactive users
+
+A user is considered inactive when they only have authorizations of type
+`user` (or none at all), and their last activity (or creation date if they
+never had any) is older than `APP_USERS_INACTIVITY_TIME` months.
+
+Two environment variables control this step, in order to help complying
+with the GDPR:
+
+- `APP_USERS_INACTIVITY_TIME` (default `12`): the number of months after
+  which a user is considered inactive. Set to `0` or a negative value to
+  disable the detection entirely (this also disables the automatic cleanup
+  below).
+- `APP_USERS_INACTIVITY_AUTO` (default `none`): the action to apply
+  automatically. Can be `none` (do nothing, the admin must act manually),
+  `anonymize` (irreversible) or `delete` (irreversible). An unknown value
+  is logged as a warning and the cleanup is skipped.

--- a/env.sample
+++ b/env.sample
@@ -33,6 +33,17 @@ APP_BASE_URL="https://support.example.org"
 # Default is 12. Set to 0 or a negative value to disable the detection.
 # APP_USERS_INACTIVITY_TIME=12
 
+# Defines an automatic action to apply to inactive users (as detected by
+# APP_USERS_INACTIVITY_TIME), in order to help complying with the GDPR. It can
+# be:
+# - "none" (default): do nothing, you must act manually on inactive users.
+# - "anonymize": automatically anonymize inactive users.
+# - "delete": automatically delete inactive users.
+# Be aware that "anonymize" and "delete" are irreversible actions applied
+# without human intervention. If APP_USERS_INACTIVITY_TIME is set to 0 or a
+# negative value, this option has no effect.
+# APP_USERS_INACTIVITY_AUTO="none"
+
 #################################
 # Configuration of the database #
 #################################

--- a/env.sample
+++ b/env.sample
@@ -27,6 +27,12 @@ APP_BASE_URL="https://support.example.org"
 # Default is var/uploads/ in the root directory.
 # APP_UPLOADS_DIRECTORY="/path/to/uploads"
 
+# The number of months after which a user with no (or only "user") authorization
+# is considered inactive. This is used to suggest the anonymization or the
+# deletion of inactive users, in order to help complying with the GDPR.
+# Default is 12. Set to 0 or a negative value to disable the detection.
+# APP_USERS_INACTIVITY_TIME=12
+
 #################################
 # Configuration of the database #
 #################################

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -10,6 +10,7 @@ use App\Entity;
 use App\Form;
 use App\Repository;
 use App\Service;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -22,10 +23,13 @@ class UsersController extends BaseController
         private readonly Service\Sorter\UserSorter $userSorter,
         private readonly Service\UserCreator $userCreator,
         private readonly Repository\AuthorizationRepository $authorizationRepository,
+        private readonly Repository\EntityEventRepository $entityEventRepository,
         private readonly Repository\SessionLogRepository $sessionLogRepository,
         private readonly Service\Sorter\AuthorizationSorter $authorizationSorter,
         private readonly Service\UserService $userService,
         private readonly TranslatorInterface $translator,
+        #[Autowire(env: 'int:APP_USERS_INACTIVITY_TIME')]
+        private readonly int $usersInactivityMonths,
     ) {
     }
 
@@ -37,8 +41,17 @@ class UsersController extends BaseController
         $users = $this->userRepository->findAllWithAuthorizations();
         $this->userSorter->sort($users);
 
+        $lastActivities = [];
+        if ($this->usersInactivityMonths > 0) {
+            foreach ($users as $user) {
+                $lastActivities[$user->getId()] = $this->entityEventRepository->findLastActivityAtForUser($user);
+            }
+        }
+
         return $this->render('users/index.html.twig', [
             'users' => $users,
+            'monthsThreshold' => $this->usersInactivityMonths,
+            'lastActivities' => $lastActivities,
         ]);
     }
 
@@ -80,11 +93,18 @@ class UsersController extends BaseController
 
         $sessionLogs = $this->sessionLogRepository->findByIdentifier($user->getUserIdentifier());
 
+        $lastActivityAt = null;
+        if ($this->usersInactivityMonths > 0) {
+            $lastActivityAt = $this->entityEventRepository->findLastActivityAtForUser($user);
+        }
+
         return $this->render('users/show.html.twig', [
             'user' => $user,
             'defaultOrganization' => $defaultOrganization,
             'authorizations' => $authorizations,
             'sessionLogs' => $sessionLogs,
+            'monthsThreshold' => $this->usersInactivityMonths,
+            'lastActivityAt' => $lastActivityAt,
         ]);
     }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -393,7 +393,25 @@ class User implements
         return $this->anonymizedAt !== null;
     }
 
-    public function anonymize(string $name, self $by): static
+    public function isInactive(
+        int $monthsThreshold,
+        ?\DateTimeImmutable $lastActivityAt,
+    ): bool {
+        if ($monthsThreshold <= 0) {
+            return false;
+        }
+
+        if ($this->isAnonymized()) {
+            return false;
+        }
+
+        $threshold = Utils\Time::ago($monthsThreshold, 'months');
+        $reference = $lastActivityAt ?? $this->createdAt;
+
+        return $reference < $threshold;
+    }
+
+    public function anonymize(string $name, ?self $by): static
     {
         $this->disableLogin();
 

--- a/src/MessageHandler/CleanDataHandler.php
+++ b/src/MessageHandler/CleanDataHandler.php
@@ -8,8 +8,10 @@ namespace App\MessageHandler;
 
 use App\Message;
 use App\Repository;
+use App\Service;
 use App\Utils;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -19,7 +21,13 @@ class CleanDataHandler
         private Repository\EntityEventRepository $entityEventRepository,
         private Repository\TokenRepository $tokenRepository,
         private Repository\SessionLogRepository $sessionLogRepository,
+        private Repository\UserRepository $userRepository,
+        private Service\UserService $userService,
         private LoggerInterface $logger,
+        #[Autowire(env: 'int:APP_USERS_INACTIVITY_TIME')]
+        private int $usersInactivityMonths,
+        #[Autowire(env: 'APP_USERS_INACTIVITY_AUTO')]
+        private string $usersInactivityAuto,
     ) {
     }
 
@@ -28,6 +36,7 @@ class CleanDataHandler
         $this->cleanInvalidTokens();
         $this->cleanOldSessionLogs();
         $this->cleanExpiredEntityEvents();
+        $this->cleanInactiveUsers();
     }
 
     private function cleanInvalidTokens(): void
@@ -57,6 +66,49 @@ class CleanDataHandler
 
         if ($countRemovedEvents > 0) {
             $this->logger->notice("[CleanData] {$countRemovedEvents} entity event(s) deleted");
+        }
+    }
+
+    private function cleanInactiveUsers(): void
+    {
+        if ($this->usersInactivityMonths <= 0) {
+            return;
+        }
+
+        if ($this->usersInactivityAuto === 'none') {
+            return;
+        }
+
+        if (!in_array($this->usersInactivityAuto, ['anonymize', 'delete'], true)) {
+            $this->logger->warning(
+                "[CleanData] Unknown APP_USERS_INACTIVITY_AUTO value " .
+                "'{$this->usersInactivityAuto}', skipping inactive users cleanup"
+            );
+            return;
+        }
+
+        $inactiveUsers = $this->userRepository->findInactive($this->usersInactivityMonths);
+        $countProcessed = 0;
+
+        foreach ($inactiveUsers as $user) {
+            try {
+                if ($this->usersInactivityAuto === 'anonymize') {
+                    $this->userService->anonymize($user);
+                } else {
+                    $this->userRepository->remove($user, true);
+                }
+                $countProcessed++;
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    "[CleanData] Failed to {$this->usersInactivityAuto} " .
+                    "inactive user #{$user->getId()}: {$e->getMessage()}"
+                );
+            }
+        }
+
+        if ($countProcessed > 0) {
+            $action = $this->usersInactivityAuto === 'anonymize' ? 'anonymized' : 'deleted';
+            $this->logger->notice("[CleanData] {$countProcessed} inactive user(s) {$action}");
         }
     }
 }

--- a/src/Repository/EntityEventRepository.php
+++ b/src/Repository/EntityEventRepository.php
@@ -27,6 +27,26 @@ class EntityEventRepository extends ServiceEntityRepository implements Uid\UidGe
         parent::__construct($registry, Entity\EntityEvent::class);
     }
 
+    public function findLastActivityAtForUser(Entity\User $user): ?\DateTimeImmutable
+    {
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT MAX(ee.createdAt)
+            FROM App\Entity\EntityEvent ee
+            WHERE ee.createdBy = :user
+        SQL);
+        $query->setParameter('user', $user);
+
+        $result = $query->getSingleScalarResult();
+
+        if ($result === null) {
+            return null;
+        }
+
+        return new \DateTimeImmutable((string) $result);
+    }
+
     public function removeByEntity(ActivityMonitor\RecordableEntityInterface $entity): int
     {
         $entityManager = $this->getEntityManager();

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -10,6 +10,7 @@ use App\Entity\Organization;
 use App\Entity\User;
 use App\Uid\UidGeneratorInterface;
 use App\Uid\UidGeneratorTrait;
+use App\Utils;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
@@ -31,8 +32,10 @@ class UserRepository extends ServiceEntityRepository implements
     /** @phpstan-use FindOrCreateTrait<User> */
     use FindOrCreateTrait;
 
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private EntityEventRepository $entityEventRepository,
+    ) {
         parent::__construct($registry, User::class);
     }
 
@@ -143,6 +146,61 @@ class UserRepository extends ServiceEntityRepository implements
         $query->setParameter('types', $types);
 
         return $query->getResult();
+    }
+
+    /**
+     * Return the list of users considered inactive.
+     *
+     * A user is considered inactive when they are not anonymized, have
+     * no authorization (or only authorizations whose role type is "user"),
+     * and their last activity is older than $monthsThreshold months. The
+     * last activity is the createdAt of the most recent EntityEvent they
+     * created, or their own createdAt as a fallback when they have no
+     * event.
+     *
+     * The feature is disabled when $monthsThreshold is zero or negative,
+     * in which case this method returns an empty list.
+     *
+     * @return User[]
+     */
+    public function findInactive(int $monthsThreshold): array
+    {
+        if ($monthsThreshold <= 0) {
+            return [];
+        }
+
+        $threshold = Utils\Time::ago($monthsThreshold, 'months');
+
+        $entityManager = $this->getEntityManager();
+
+        $query = $entityManager->createQuery(<<<SQL
+            SELECT u
+            FROM App\Entity\User u
+            WHERE u.anonymizedAt IS NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM App\Entity\Authorization a
+                JOIN a.role r
+                WHERE a.holder = u
+                AND r.type != :roleTypeUser
+            )
+        SQL);
+
+        $query->setParameter('roleTypeUser', 'user');
+
+        $candidates = $query->getResult();
+
+        $inactiveUsers = [];
+        foreach ($candidates as $user) {
+            $lastActivityAt = $this->entityEventRepository->findLastActivityAtForUser($user);
+            $referenceDate = $lastActivityAt ?? $user->getCreatedAt();
+
+            if ($referenceDate !== null && $referenceDate < $threshold) {
+                $inactiveUsers[] = $user;
+            }
+        }
+
+        return $inactiveUsers;
     }
 
     public function findOneByResetPasswordToken(string $token): ?User

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -44,6 +44,30 @@
 
         {% if user != app.user %}
             <div class="panel">
+                <form action="{{ path('new user anonymization', { uid: user.uid }) }}" method="post" class="form--standard">
+                    <h2>{{ 'users.anonymization.title' | trans }}</h2>
+
+                    {{ include('alerts/_alert.html.twig', {
+                        type: 'warning',
+                        title: 'common.caution' | trans,
+                        message: 'anonymizations.new.information' | trans({ user: user.displayName }),
+                    }, with_context = false) }}
+
+                    <div class="form__actions">
+                        <button
+                            class="button--primary"
+                            type="submit"
+                            data-turbo-confirm="{{ 'users.anonymization.confirm' | trans }}"
+                        >
+                            {{ 'users.show.anonymize' | trans }}
+                        </button>
+                    </div>
+
+                    <input type="hidden" name="anonymization[_token]" value="{{ csrf_token('anonymization') }}">
+                </form>
+            </div>
+
+            <div class="panel">
                 <form action="{{ path('delete user', { uid: user.uid }) }}" method="post" class="form--standard">
                     <h2>{{ 'users.deletion.title' | trans }}</h2>
 

--- a/templates/users/index.html.twig
+++ b/templates/users/index.html.twig
@@ -67,6 +67,12 @@
                             </span>
 
                             <div class="col--noshrink">
+                                {% if user.isInactive(monthsThreshold, lastActivities[user.id] ?? null) %}
+                                    <span class="badge badge--orange" data-test="inactive-badge">
+                                        {{ 'users.index.inactive_badge' | trans }}
+                                    </span>
+                                {% endif %}
+
                                 <span class="badge badge--grey">
                                     {{ 'users.index.authorizations' | trans({ count: user.authorizations|length }) }}
                                 </span>

--- a/templates/users/show.html.twig
+++ b/templates/users/show.html.twig
@@ -112,6 +112,14 @@
                             {{ 'users.show.cannot_login' | trans }}
                         </p>
                     {% endif %}
+
+                    {% if user.isInactive(monthsThreshold, lastActivityAt) %}
+                        <p class="alert alert--warning" data-test="inactive-warning">
+                            {{ 'users.show.inactive_warning' | trans({
+                                edit_url: path('edit user', { uid: user.uid }),
+                            }) | raw }}
+                        </p>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/tests/MessageHandler/CleanDataHandlerTest.php
+++ b/tests/MessageHandler/CleanDataHandlerTest.php
@@ -8,9 +8,12 @@ namespace App\Tests\MessageHandler;
 
 use App\Entity;
 use App\Message;
+use App\MessageHandler\CleanDataHandler;
 use App\Repository;
+use App\Service;
 use App\Tests\Factory;
 use App\Utils;
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Zenstruck\Foundry\Test\Factories;
@@ -120,5 +123,103 @@ class CleanDataHandlerTest extends WebTestCase
         $this->assertContains($entityEventNotTooOldExpired->getId(), $entityEventIds);
         $this->assertContains($entityEventDeleteExpired->getId(), $entityEventIds);
         $this->assertContains($entityEventNotExpired->getId(), $entityEventIds);
+    }
+
+    public function testInvokeDoesNothingWhenAutoIsNone(): void
+    {
+        $inactiveUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $handler = $this->buildHandler(12, 'none');
+        $handler(new Message\CleanData());
+
+        $this->assertSame(1, Factory\UserFactory::count());
+        $inactiveUser->_refresh();
+        $this->assertFalse($inactiveUser->isAnonymized());
+    }
+
+    public function testInvokeAnonymizesInactiveUsers(): void
+    {
+        $inactiveUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $activeUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(3, 'months'),
+        ]);
+
+        $handler = $this->buildHandler(12, 'anonymize');
+        $handler(new Message\CleanData());
+
+        $inactiveUser->_refresh();
+        $this->assertTrue($inactiveUser->isAnonymized());
+        $this->assertNull($inactiveUser->getAnonymizedBy());
+
+        $activeUser->_refresh();
+        $this->assertFalse($activeUser->isAnonymized());
+    }
+
+    public function testInvokeDeletesInactiveUsers(): void
+    {
+        $inactiveUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $activeUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(3, 'months'),
+        ]);
+        $inactiveUserId = $inactiveUser->getId();
+        $activeUserId = $activeUser->getId();
+
+        $handler = $this->buildHandler(12, 'delete');
+        $handler(new Message\CleanData());
+
+        $this->assertSame(1, Factory\UserFactory::count());
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $this->assertNull($userRepository->find($inactiveUserId));
+        $this->assertNotNull($userRepository->find($activeUserId));
+    }
+
+    public function testInvokeDoesNothingWhenThresholdIsDisabled(): void
+    {
+        $inactiveUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $handler = $this->buildHandler(0, 'anonymize');
+        $handler(new Message\CleanData());
+
+        $this->assertSame(1, Factory\UserFactory::count());
+        $inactiveUser->_refresh();
+        $this->assertFalse($inactiveUser->isAnonymized());
+    }
+
+    public function testInvokeDoesNothingWhenAutoIsInvalid(): void
+    {
+        $inactiveUser = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $handler = $this->buildHandler(12, 'banana');
+        $handler(new Message\CleanData());
+
+        $this->assertSame(1, Factory\UserFactory::count());
+        $inactiveUser->_refresh();
+        $this->assertFalse($inactiveUser->isAnonymized());
+    }
+
+    private function buildHandler(int $monthsThreshold, string $auto): CleanDataHandler
+    {
+        $container = static::getContainer();
+        return new CleanDataHandler(
+            $container->get(Repository\EntityEventRepository::class),
+            $container->get(Repository\TokenRepository::class),
+            $container->get(Repository\SessionLogRepository::class),
+            $container->get(Repository\UserRepository::class),
+            $container->get(Service\UserService::class),
+            new NullLogger(),
+            $monthsThreshold,
+            $auto,
+        );
     }
 }

--- a/tests/Repository/EntityEventRepositoryTest.php
+++ b/tests/Repository/EntityEventRepositoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2026 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Repository;
+
+use App\Entity;
+use App\Repository;
+use App\Tests\Factory;
+use App\Utils;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class EntityEventRepositoryTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testFindLastActivityAtForUserReturnsNullWhenUserHasNoEvents(): void
+    {
+        /** @var Repository\EntityEventRepository */
+        $entityEventRepository = Factory\EntityEventFactory::repository();
+        $user = Factory\UserFactory::createOne();
+
+        $lastActivityAt = $entityEventRepository->findLastActivityAtForUser($user->_real());
+
+        $this->assertNull($lastActivityAt);
+    }
+
+    public function testFindLastActivityAtForUserReturnsMostRecentCreatedAt(): void
+    {
+        /** @var Repository\EntityEventRepository */
+        $entityEventRepository = Factory\EntityEventFactory::repository();
+        $user = Factory\UserFactory::createOne();
+        $expectedDate = Utils\Time::ago(1, 'day');
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'weeks'),
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'insert',
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => $expectedDate,
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -2,
+            'type' => 'insert',
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(1, 'week'),
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -3,
+            'type' => 'update',
+        ]);
+
+        $lastActivityAt = $entityEventRepository->findLastActivityAtForUser($user->_real());
+
+        $this->assertNotNull($lastActivityAt);
+        $this->assertSame($expectedDate->getTimestamp(), $lastActivityAt->getTimestamp());
+    }
+
+    public function testFindLastActivityAtForUserIgnoresEventsCreatedByOtherUsers(): void
+    {
+        /** @var Repository\EntityEventRepository */
+        $entityEventRepository = Factory\EntityEventFactory::repository();
+        $userA = Factory\UserFactory::createOne();
+        $userB = Factory\UserFactory::createOne();
+        $userBDate = Utils\Time::ago(2, 'weeks');
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(1, 'hour'),
+            'createdBy' => $userA,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'insert',
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => $userBDate,
+            'createdBy' => $userB,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -2,
+            'type' => 'insert',
+        ]);
+
+        $lastActivityAt = $entityEventRepository->findLastActivityAtForUser($userB->_real());
+
+        $this->assertNotNull($lastActivityAt);
+        $this->assertSame($userBDate->getTimestamp(), $lastActivityAt->getTimestamp());
+    }
+
+    public function testFindLastActivityAtForUserIgnoresEventsWhereUserIsOnlyUpdatedBy(): void
+    {
+        /** @var Repository\EntityEventRepository */
+        $entityEventRepository = Factory\EntityEventFactory::repository();
+        $userA = Factory\UserFactory::createOne();
+        $userB = Factory\UserFactory::createOne();
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(1, 'day'),
+            'createdBy' => $userA,
+            'updatedBy' => $userB,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'update',
+        ]);
+
+        $lastActivityAt = $entityEventRepository->findLastActivityAtForUser($userB->_real());
+
+        $this->assertNull($lastActivityAt);
+    }
+}

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -1,0 +1,218 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2026 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Repository;
+
+use App\Entity;
+use App\Repository;
+use App\Tests\Factory;
+use App\Utils;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class UserRepositoryTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testFindInactiveReturnsEmptyWhenThresholdIsZero(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(0);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveReturnsEmptyWhenThresholdIsNegative(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(-5);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveExcludesAnonymizedUsers(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+            'anonymizedAt' => Utils\Time::ago(1, 'day'),
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveExcludesUsersWithAdminAuthorization(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'admin']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveExcludesUsersWithAgentAuthorization(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'agent']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveExcludesUsersWithSuperAuthorization(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'super']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveListsUsersWithOnlyUserAuthorizationAndOldActivity(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'user']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'insert',
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertCount(1, $inactiveUsers);
+        $this->assertSame($user->getId(), $inactiveUsers[0]->getId());
+    }
+
+    public function testFindInactiveExcludesUsersWithOnlyUserAuthorizationAndRecentActivity(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(3, 'months'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'user']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(1, 'month'),
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'insert',
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveListsUsersWithNoAuthorizationAndOldCreatedAt(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertCount(1, $inactiveUsers);
+        $this->assertSame($user->getId(), $inactiveUsers[0]->getId());
+    }
+
+    public function testFindInactiveExcludesUsersWithNoAuthorizationAndRecentCreatedAt(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(3, 'months'),
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+
+    public function testFindInactiveExcludesUsersWithOnlyUserAuthorizationButRecentEvents(): void
+    {
+        /** @var Repository\UserRepository */
+        $userRepository = Factory\UserFactory::repository();
+        $user = Factory\UserFactory::createOne([
+            'createdAt' => Utils\Time::ago(2, 'years'),
+        ]);
+        $role = Factory\RoleFactory::createOne(['type' => 'user']);
+        Factory\AuthorizationFactory::createOne([
+            'holder' => $user,
+            'role' => $role,
+        ]);
+        Factory\EntityEventFactory::createOne([
+            'createdAt' => Utils\Time::ago(1, 'month'),
+            'createdBy' => $user,
+            'entityType' => Entity\Ticket::class,
+            'entityId' => -1,
+            'type' => 'insert',
+        ]);
+
+        $inactiveUsers = $userRepository->findInactive(12);
+
+        $this->assertEmpty($inactiveUsers);
+    }
+}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -637,6 +637,8 @@ tickets.urgency.high: High
 tickets.urgency.low: Low
 tickets.urgency.medium: Medium
 time_spents.edit.title: 'Edit time spent'
+users.anonymization.confirm: 'Are you sure that you want to anonymize this user?'
+users.anonymization.title: Anonymization
 users.anonymous: 'Anonymous user'
 users.color_scheme: 'Color scheme'
 users.color_scheme.auto: Auto
@@ -655,6 +657,7 @@ users.form.password.empty_keep_current: 'Leave blank to keep the current passwor
 users.form.prevent_login: 'Prevent the user from logging in to the Web interface'
 users.identifier: 'Email address or identifier'
 users.index.authorizations: '{count, plural, =0 {No authorizations} one {1 authorization} other {# authorizations}}'
+users.index.inactive_badge: Inactive
 users.index.new_user: 'New user'
 users.index.no_users: 'No users'
 users.index.number: '{count, plural, =0 {No users} one {1 user} other {# users}}'
@@ -673,6 +676,7 @@ users.show.authorizations.title: Authorizations
 users.show.cannot_login: 'This user does not have permission to login to the Web interface.'
 users.show.edit: 'Edit the user'
 users.show.email: 'Email: {email}'
+users.show.inactive_warning: 'This user has been inactive for a long time. You should consider <a href="{edit_url}">anonymizing or deleting them</a>.'
 users.show.is_anonymized: 'This user has been anonymized by {by} the {date}.'
 users.show.ldap_identifier: 'LDAP identifier: {identifier}'
 users.show.name: 'Name: {name}'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -637,6 +637,8 @@ tickets.urgency.high: Haute
 tickets.urgency.low: Basse
 tickets.urgency.medium: Moyenne
 time_spents.edit.title: 'Modifier du temps passé'
+users.anonymization.confirm: "Êtes-vous sûr de vouloir anonymiser cet utilisateur\_?"
+users.anonymization.title: Anonymisation
 users.anonymous: 'Utilisateur anonyme'
 users.color_scheme: 'Schéma de couleurs'
 users.color_scheme.auto: Auto
@@ -655,6 +657,7 @@ users.form.password.empty_keep_current: 'Laissez vide pour conserver le mot de p
 users.form.prevent_login: 'Empêcher l’utilisateur de se connecter à l’interface Web'
 users.identifier: 'Adresse email ou identifiant'
 users.index.authorizations: '{count, plural, =0 {Aucune autorisation} one {1 autorisation} other {# autorisations}}'
+users.index.inactive_badge: Inactif
 users.index.new_user: 'Nouvel utilisateur'
 users.index.no_users: 'Aucun utilisateur'
 users.index.number: '{count, plural, =0 {Aucun utilisateur} one {1 utilisateur} other {# utilisateurs}}'
@@ -673,6 +676,7 @@ users.show.authorizations.title: Autorisations
 users.show.cannot_login: 'Cet utilisateur n’a pas la permission de se connecter à l’interface Web.'
 users.show.edit: 'Modifier l’utilisateur'
 users.show.email: "Email\_: {email}"
+users.show.inactive_warning: 'Cet utilisateur est inactif depuis longtemps. Vous devriez envisager de <a href="{edit_url}">l’anonymiser ou le supprimer</a>.'
 users.show.is_anonymized: 'Cet utilisateur a été anonymisé par {by} le {date}.'
 users.show.ldap_identifier: "Identifiant LDAP\_: {identifier}"
 users.show.name: "Nom\_: {name}"


### PR DESCRIPTION
## Related issue(s)

Closes #940.

Detects inactive users to help complying with the GDPR, suggests the
admin to anonymize or delete them, and optionally applies the action
automatically.

A user is considered inactive when they only have authorizations of
type user (or none at all), and their last activity (or creation
date if they never had any) is older than APP_USERS_INACTIVITY_TIME
months (default 12).

Three commits, each one self-contained:

1. **Detection** via UserRepository::findInactive(), relying on
   EntityEventRepository::findLastActivityAtForUser().
2. **Display** of an orange Inactive badge on the users index, plus
   a warning paragraph on the user profile suggesting to act.
3. **Auto-cleanup** in CleanDataHandler driven by
   APP_USERS_INACTIVITY_AUTO (none by default).

A few decisions worth flagging:

- **Inactivity definition**: I went with no EntityEvent produced for
  N months, with a fallback on User.createdAt. Felt the most
  semantically correct in a GDPR context. Open to your feedback.
- **User::anonymize($name, ?self $by)**: signature relaxed from
  self to ?self to allow auto-anonymization from the handler
  (no authenticated user). The DB column was already nullable, this
  just aligns the PHP signature with the schema.
- **Anonymization panel on the user edit page**: added so the warning
  can link to a single page where both anonymize and delete are
  available. The existing modal entry in the show page Actions menu
  is untouched.

## How to test manually

Pre-requisites:

- A user with no authorization (or only user authorizations) and
  whose createdAt is older than APP_USERS_INACTIVITY_TIME months
  (or set the variable to 1 in .env.local for faster tests).

Detection & display (Commit 2):

1. Go to /users. The inactive user shows an orange Inactive badge.
2. Open the user profile. A warning paragraph suggests to anonymize
   or delete them, linking to the edit page.
3. On the edit page, you should see two panels at the bottom:
   Anonymization (new) and Deletion (existing). Both trigger a
   native browser confirm popup on submit.
4. Confirm the anonymization → user is anonymized and you are
   redirected to the show page with the standard "anonymized by..."
   message.

Auto-cleanup (Commit 3):

1. In .env.local, set APP_USERS_INACTIVITY_TIME=1 and
   APP_USERS_INACTIVITY_AUTO=anonymize (or delete).
2. Trigger the CleanData message (either wait for the scheduler, or
   temporarily lower Schedule.php to every 1 minute).
3. Check the worker logs: [CleanData] N inactive user(s) anonymized
   (or deleted).
4. Verify in DB that the inactive users have anonymized_at set
   (or are removed if mode is delete).
5. Set APP_USERS_INACTIVITY_AUTO=banana and re-trigger: a warning
   is logged and no user is touched.
   
## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->
- [ ] Code is manually tested
- [ ] Permissions / authorizations are verified
- [ ] New data can be imported
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works in both light and dark modes
- [ ] Interface works on both Firefox and Chrome
- [ ] Accessibility has been tested
- [ ] Translations are synchronized
- [ ] Tests are up to date
- [ ] Copyright notices are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved