### PR TITLE
feat: Allow to export tickets as CSV

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method App\\Service\\TicketCsvExporter\:\:sanitizeField\(\) should return TField of int\|string\|null but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Service/TicketCsvExporter.php

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - .phpstan-baseline.neon
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon

--- a/src/Controller/Organizations/TicketsController.php
+++ b/src/Controller/Organizations/TicketsController.php
@@ -17,6 +17,7 @@ use App\Utils;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 class TicketsController extends BaseController
@@ -26,6 +27,7 @@ class TicketsController extends BaseController
         private readonly SearchEngine\Ticket\QuickSearchFilterBuilder $ticketQuickSearchFilterBuilder,
         private readonly Repository\TicketRepository $ticketRepository,
         private readonly Service\TicketAssigner $ticketAssigner,
+        private readonly Service\TicketCsvExporter $ticketCsvExporter,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -94,6 +96,46 @@ class TicketsController extends BaseController
             'quickSearchForm' => $quickSearchForm,
             'advancedSearchForm' => $advancedSearchForm,
         ]);
+    }
+
+    #[Route('/organizations/{uid:organization}/tickets.csv', name: 'organization tickets csv', methods: ['GET'])]
+    public function csv(Entity\Organization $organization, Request $request): Response
+    {
+        $this->denyAccessUnlessGranted('orga:see', $organization);
+
+        $view = $request->query->getString('view', 'all');
+        $sort = $request->query->getString('sort', 'updated-desc');
+
+        if ($view === 'unassigned') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryUnassigned();
+        } elseif ($view === 'assigned-me') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryAssignedMe();
+        } elseif ($view === 'owned') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryOwned();
+        } else {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryDefault();
+        }
+
+        $advancedSearchForm = $this->createNamedForm('', Form\AdvancedSearchForm::class, [
+            'q' => $defaultQuery,
+        ]);
+        $advancedSearchForm->handleRequest($request);
+
+        $query = $advancedSearchForm->get('q')->getData();
+
+        $this->ticketSearcher->setOrganization($organization);
+
+        /** @var iterable<Entity\Ticket> $tickets */
+        $tickets = $this->ticketSearcher->getTicketsQuery($query, $sort)->toIterable();
+
+        $response = new StreamedResponse($this->ticketCsvExporter->stream($tickets, $request->getLocale()));
+
+        $filename = sprintf('bileto-tickets-%s-%s.csv', $organization->getUid(), date('Y-m-d'));
+
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set('Content-Disposition', "attachment; filename=\"{$filename}\"");
+
+        return $response;
     }
 
     #[Route('/organizations/{uid:organization}/tickets/new', name: 'new organization ticket')]

--- a/src/Controller/TicketsController.php
+++ b/src/Controller/TicketsController.php
@@ -16,6 +16,7 @@ use App\Service;
 use App\Utils;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -28,6 +29,7 @@ class TicketsController extends BaseController
         private readonly Security\Authorizer $authorizer,
         private readonly Service\UserService $userService,
         private readonly Service\TicketTimeline $ticketTimeline,
+        private readonly Service\TicketCsvExporter $ticketCsvExporter,
     ) {
     }
 
@@ -102,6 +104,48 @@ class TicketsController extends BaseController
             'mustSelectOrganization' => $mustSelectOrganization,
             'defaultOrganization' => $defaultOrganization,
         ]);
+    }
+
+    #[Route('/tickets.csv', name: 'tickets csv', methods: ['GET'])]
+    public function csv(Request $request): Response
+    {
+        $view = $request->query->getString('view', 'all');
+        $sort = $request->query->getString('sort', 'updated-desc');
+
+        if ($view === 'unassigned') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryUnassigned();
+        } elseif ($view === 'assigned-me') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryAssignedMe();
+        } elseif ($view === 'owned') {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryOwned();
+        } else {
+            $defaultQuery = SearchEngine\Ticket\Searcher::queryDefault();
+        }
+
+        $advancedSearchForm = $this->createNamedForm('', Form\AdvancedSearchForm::class, [
+            'q' => $defaultQuery,
+        ]);
+        $advancedSearchForm->handleRequest($request);
+
+        $query = $advancedSearchForm->get('q')->getData();
+
+        /** @var Entity\User */
+        $user = $this->getUser();
+        $organizations = $this->organizationRepository->findAuthorizedOrganizations($user);
+
+        $this->ticketSearcher->setOrganizations($organizations);
+
+        /** @var iterable<Entity\Ticket> */
+        $tickets = $this->ticketSearcher->getTicketsQuery($query, $sort)->toIterable();
+
+        $response = new StreamedResponse($this->ticketCsvExporter->stream($tickets, $request->getLocale()));
+
+        $filename = sprintf('bileto-tickets-%s.csv', date('Y-m-d'));
+
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set('Content-Disposition', "attachment; filename=\"{$filename}\"");
+
+        return $response;
     }
 
     #[Route('/tickets/new', name: 'new ticket')]

--- a/src/SearchEngine/QueryBuilder.php
+++ b/src/SearchEngine/QueryBuilder.php
@@ -41,6 +41,11 @@ abstract class QueryBuilder
         $queryBuilder->select(static::getFromAlias());
         $queryBuilder->from(static::getFrom(), static::getFromAlias());
 
+        // Marking the query as distinct shouldn't be necessary, but it seems
+        // to be required to get an iterable from the query.
+        // @see https://github.com/doctrine/orm/issues/5868
+        $queryBuilder->distinct();
+
         $this->subBuilderSequence = 0;
 
         foreach ($queries as $sequence => $query) {

--- a/src/SearchEngine/Ticket/Searcher.php
+++ b/src/SearchEngine/Ticket/Searcher.php
@@ -10,6 +10,7 @@ use App\Entity;
 use App\SearchEngine;
 use App\Security;
 use App\Utils;
+use Doctrine\ORM;
 
 /**
  * @phpstan-import-type PaginationOptions from Utils\Pagination
@@ -96,21 +97,20 @@ class Searcher
             ];
         }
 
-        $sort = $this->processSort($sort);
-
-        $queries = [$this->orgaQuery];
-
-        if ($query) {
-            $queries[] = $query;
-        }
-
-        $queryBuilder = $this->ticketQueryBuilder->create($queries);
-        $queryBuilder->orderBy("t.{$sort[0]}", $sort[1]);
+        $queryBuilder = $this->buildTicketsQueryBuilder($query, $sort);
 
         /** @var Utils\Pagination<Entity\Ticket> */
         $pagination = Utils\Pagination::paginate($queryBuilder->getQuery(), $paginationOptions);
 
         return $pagination;
+    }
+
+    /**
+     * @return ORM\Query<null, Entity\Ticket>
+     */
+    public function getTicketsQuery(?SearchEngine\Query $query = null, string $sort = ''): ORM\Query
+    {
+        return $this->buildTicketsQueryBuilder($query, $sort)->getQuery();
     }
 
     public function countTickets(?SearchEngine\Query $query = null): int
@@ -144,6 +144,22 @@ class Searcher
     public static function queryUnassigned(): SearchEngine\Query
     {
         return SearchEngine\Query::fromString(self::QUERY_UNASSIGNED);
+    }
+
+    private function buildTicketsQueryBuilder(?SearchEngine\Query $query, string $sort): ORM\QueryBuilder
+    {
+        $sort = $this->processSort($sort);
+
+        $queries = [$this->orgaQuery];
+
+        if ($query) {
+            $queries[] = $query;
+        }
+
+        $queryBuilder = $this->ticketQueryBuilder->create($queries);
+        $queryBuilder->orderBy("t.{$sort[0]}", $sort[1]);
+
+        return $queryBuilder;
     }
 
     /**

--- a/src/Service/TicketCsvExporter.php
+++ b/src/Service/TicketCsvExporter.php
@@ -1,0 +1,179 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2026 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Service;
+
+use App\Entity;
+use App\Security;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TicketCsvExporter
+{
+    public function __construct(
+        private Security\Authorizer $authorizer,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @param iterable<Entity\Ticket> $tickets
+     */
+    public function stream(iterable $tickets, string $locale): \Closure
+    {
+        return function () use ($tickets, $locale): void {
+            $handle = fopen('php://output', 'wb');
+            if ($handle === false) {
+                return;
+            }
+
+            $this->writeHeader($handle, $locale);
+
+            foreach ($tickets as $ticket) {
+                $this->writeRow($handle, $locale, $ticket);
+                fflush($handle);
+            }
+
+            fclose($handle);
+        };
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function writeHeader($handle, string $locale): void
+    {
+        fputcsv($handle, [
+            $this->translator->trans('tickets.export.column.id', locale: $locale),
+            $this->translator->trans('tickets.export.column.uid', locale: $locale),
+            $this->translator->trans('tickets.export.column.created_at', locale: $locale),
+            $this->translator->trans('tickets.export.column.created_by', locale: $locale),
+            $this->translator->trans('tickets.export.column.updated_at', locale: $locale),
+            $this->translator->trans('tickets.export.column.updated_by', locale: $locale),
+            $this->translator->trans('tickets.export.column.type', locale: $locale),
+            $this->translator->trans('tickets.export.column.status', locale: $locale),
+            $this->translator->trans('tickets.export.column.title', locale: $locale),
+            $this->translator->trans('tickets.export.column.urgency', locale: $locale),
+            $this->translator->trans('tickets.export.column.impact', locale: $locale),
+            $this->translator->trans('tickets.export.column.priority', locale: $locale),
+            $this->translator->trans('tickets.export.column.requester', locale: $locale),
+            $this->translator->trans('tickets.export.column.assignee', locale: $locale),
+            $this->translator->trans('tickets.export.column.team', locale: $locale),
+            $this->translator->trans('tickets.export.column.observers', locale: $locale),
+            $this->translator->trans('tickets.export.column.organization', locale: $locale),
+            $this->translator->trans('tickets.export.column.solution', locale: $locale),
+            $this->translator->trans('tickets.export.column.contracts', locale: $locale),
+            $this->translator->trans('tickets.export.column.time_spent.real', locale: $locale),
+            $this->translator->trans('tickets.export.column.time_spent.accounted', locale: $locale),
+            $this->translator->trans('tickets.export.column.time_spent.unaccounted', locale: $locale),
+            $this->translator->trans('tickets.export.column.labels', locale: $locale),
+        ], escape: '');
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function writeRow($handle, string $locale, Entity\Ticket $ticket): void
+    {
+        $organization = $ticket->getOrganization();
+
+        $isAgent = $this->authorizer->isAgent($organization);
+        $canSeeContracts = $this->authorizer->isGranted('orga:see:tickets:contracts', $organization);
+        $canSeeRealTimeSpent = $this->authorizer->isGranted('orga:see:tickets:time_spent:real', $organization);
+        $canSeeAccountedTimeSpent = $this->authorizer->isGranted(
+            'orga:see:tickets:time_spent:accounted',
+            $organization,
+        );
+
+        $observers = array_map(
+            function (Entity\User $observer) use ($isAgent): string {
+                return $this->exportUser($observer, exportEmail: $isAgent);
+            },
+            $ticket->getObservers()->toArray(),
+        );
+        $contracts = array_map(
+            function (Entity\Contract $contract): string {
+                return $this->sanitizeField($contract->getName() ?? '');
+            },
+            $ticket->getContracts()->toArray(),
+        );
+        $labels = array_map(
+            function (Entity\Label $label): string {
+                return $this->sanitizeField($label->getName() ?? '');
+            },
+            $ticket->getLabels()->toArray(),
+        );
+
+        if ($ticket->hasSolution()) {
+            $solutionLabel = $this->translator->trans('tickets.export.solution.yes', locale: $locale);
+        } else {
+            $solutionLabel = $this->translator->trans('tickets.export.solution.no', locale: $locale);
+        }
+
+        fputcsv($handle, [
+            $ticket->getId(),
+            $ticket->getUid(),
+            $ticket->getCreatedAt()?->format('Y-m-d H:i') ?? '',
+            $this->exportUser($ticket->getCreatedBy(), exportEmail: $isAgent),
+            $ticket->getUpdatedAt()?->format('Y-m-d H:i') ?? '',
+            $this->exportUser($ticket->getUpdatedBy(), exportEmail: $isAgent),
+            $this->translator->trans("tickets.type.{$ticket->getType()}", locale: $locale),
+            $this->translator->trans("tickets.status.{$ticket->getStatus()}", locale: $locale),
+            $this->sanitizeField($ticket->getTitle()),
+            $this->translator->trans("tickets.urgency.{$ticket->getUrgency()}", locale: $locale),
+            $this->translator->trans("tickets.impact.{$ticket->getImpact()}", locale: $locale),
+            $this->translator->trans("tickets.priority.{$ticket->getPriority()}", locale: $locale),
+            $this->exportUser($ticket->getRequester(), exportEmail: $isAgent),
+            $this->exportUser($ticket->getAssignee(), exportEmail: $isAgent),
+            $this->sanitizeField($ticket->getTeam()?->getName() ?? ''),
+            implode("\n", $observers),
+            $this->sanitizeField($organization?->getName() ?? ''),
+            $solutionLabel,
+            $canSeeContracts ? implode("\n", $contracts) : '',
+            $canSeeRealTimeSpent ? $ticket->getSumTimeSpent('real') : '',
+            $canSeeAccountedTimeSpent ? $ticket->getSumTimeSpent('accounted') : '',
+            ($canSeeRealTimeSpent && $canSeeAccountedTimeSpent) ? $ticket->getSumTimeSpent('unaccounted') : '',
+            implode("\n", $labels),
+        ], escape: '');
+    }
+
+    public function exportUser(?Entity\User $user, bool $exportEmail): string
+    {
+        if (!$user) {
+            return '';
+        }
+
+        $name = $user->getDisplayName();
+        $email = $user->getEmail();
+
+        if ($exportEmail && $name !== $email) {
+            $name = "{$name} ({$email})";
+        }
+
+        return $this->sanitizeField($name);
+    }
+
+    /**
+     * @template TField of string|int|null
+     *
+     * @param TField $field
+     * @return TField
+     */
+    private function sanitizeField(mixed $field): mixed
+    {
+        if (
+            !$field ||
+            is_numeric($field)
+        ) {
+            return $field;
+        }
+
+        while ($field && in_array($field[0], ['=', '+', '-', '@', "\t", "\r", '%', '|'])) {
+            $field = substr($field, 1);
+        }
+
+        return $field;
+    }
+}

--- a/templates/organizations/tickets/index.html.twig
+++ b/templates/organizations/tickets/index.html.twig
@@ -68,14 +68,24 @@
                             {{ 'tickets.index.number' | trans({ count: ticketsPagination.countAll }) }}
                         </p>
 
-                        {{ include(
-                            'tickets/_sort_button.html.twig',
-                            {
-                                currentPath: path('organization tickets', { uid: organization.uid, q: query }),
-                                currentSort: sort,
-                            },
-                            with_context = false
-                        ) }}
+                        <div class="cols cols--always cols--center flow">
+                            {{ include(
+                                'tickets/_sort_button.html.twig',
+                                {
+                                    currentPath: path('organization tickets', { uid: organization.uid, q: query }),
+                                    currentSort: sort,
+                                },
+                                with_context = false
+                            ) }}
+
+                            <a
+                                class="button button--discreet"
+                                href="{{ path('organization tickets csv', { uid: organization.uid, q: query, sort: sort, view: view }) }}"
+                            >
+                                {{ icon('file-excel') }}
+                                {{ 'tickets.export.csv' | trans }}
+                            </a>
+                        </div>
                     </div>
 
                     {% if is_granted('orga:create:tickets', organization) %}

--- a/templates/tickets/index.html.twig
+++ b/templates/tickets/index.html.twig
@@ -71,14 +71,24 @@
                             {{ 'tickets.index.number' | trans({ count: ticketsPagination.countAll }) }}
                         </p>
 
-                        {{ include(
-                            'tickets/_sort_button.html.twig',
-                            {
-                                currentPath: path('tickets', { q: query }),
-                                currentSort: sort,
-                            },
-                            with_context = false
-                        ) }}
+                        <div class="cols cols--always cols--center flow">
+                            {{ include(
+                                'tickets/_sort_button.html.twig',
+                                {
+                                    currentPath: path('tickets', { q: query }),
+                                    currentSort: sort,
+                                },
+                                with_context = false
+                            ) }}
+
+                            <a
+                                class="button button--discreet"
+                                href="{{ path('tickets csv', { q: query, sort: sort, view: view }) }}"
+                            >
+                                {{ icon('file-excel') }}
+                                {{ 'tickets.export.csv' | trans }}
+                            </a>
+                        </div>
                     </div>
 
                     {% if is_granted('orga:create:tickets', 'any') %}

--- a/tests/Controller/Organizations/TicketsControllerTest.php
+++ b/tests/Controller/Organizations/TicketsControllerTest.php
@@ -179,6 +179,73 @@ class TicketsControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, "/organizations/{$organization->getUid()}/tickets");
     }
 
+    public function testGetCsvRendersCsv(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization->_real());
+        $ticket = Factory\TicketFactory::createOne([
+            'title' => 'My ticket',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, "/organizations/{$organization->getUid()}/tickets.csv");
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'text/csv; charset=utf-8');
+        $contentDisposition = $client->getResponse()->headers->get('Content-Disposition') ?? '';
+        $this->assertStringContainsString("bileto-tickets-{$organization->getUid()}-", $contentDisposition);
+        $this->assertStringContainsString('My ticket', $content);
+        $this->assertStringContainsString((string) $ticket->getId(), $content);
+    }
+
+    public function testGetCsvIsScopedToTheOrganization(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization1 = Factory\OrganizationFactory::createOne();
+        $organization2 = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization1->_real());
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization2->_real());
+        Factory\TicketFactory::createOne([
+            'title' => 'Targeted ticket',
+            'organization' => $organization1,
+            'status' => 'new',
+        ]);
+        Factory\TicketFactory::createOne([
+            'title' => 'Other organization ticket',
+            'organization' => $organization2,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, "/organizations/{$organization1->getUid()}/tickets.csv");
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $contentDisposition = $client->getResponse()->headers->get('Content-Disposition') ?? '';
+        $this->assertStringContainsString("bileto-tickets-{$organization1->getUid()}-", $contentDisposition);
+        $this->assertStringContainsString('Targeted ticket', $content);
+        $this->assertStringNotContainsString('Other organization ticket', $content);
+    }
+
+    public function testGetCsvFailsIfAccessIsForbidden(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+
+        $client->catchExceptions(false);
+        $client->request(Request::METHOD_GET, "/organizations/{$organization->getUid()}/tickets.csv");
+    }
+
     public function testGetNewRendersCorrectly(): void
     {
         $client = static::createClient();

--- a/tests/Controller/TicketsControllerTest.php
+++ b/tests/Controller/TicketsControllerTest.php
@@ -42,6 +42,159 @@ class TicketsControllerTest extends WebTestCase
         $this->assertSelectorTextContains('[data-test="ticket-item"]', "#{$ticket->getId()} My ticket");
     }
 
+    public function testGetCsvRendersCsv(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization->_real());
+        $ticket1 = Factory\TicketFactory::createOne([
+            'title' => 'First ticket',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+        $ticket2 = Factory\TicketFactory::createOne([
+            'title' => 'Second ticket',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/tickets.csv');
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'text/csv; charset=utf-8');
+        $contentDisposition = $client->getResponse()->headers->get('Content-Disposition') ?? '';
+        $this->assertStringStartsWith('attachment; filename="bileto-tickets-', $contentDisposition);
+        $this->assertStringContainsString('First ticket', $content);
+        $this->assertStringContainsString('Second ticket', $content);
+        $this->assertStringContainsString((string) $ticket1->getId(), $content);
+        $this->assertStringContainsString((string) $ticket2->getId(), $content);
+    }
+
+    public function testGetCsvIsScopedToUserOrganizations(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization1 = Factory\OrganizationFactory::createOne();
+        $organization2 = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization1->_real());
+        Factory\TicketFactory::createOne([
+            'title' => 'Authorized ticket',
+            'organization' => $organization1,
+            'status' => 'new',
+        ]);
+        Factory\TicketFactory::createOne([
+            'title' => 'Forbidden ticket',
+            'organization' => $organization2,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/tickets.csv');
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Authorized ticket', $content);
+        $this->assertStringNotContainsString('Forbidden ticket', $content);
+    }
+
+    public function testGetCsvAppliesQueryAndSort(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization->_real());
+        Factory\TicketFactory::createOne([
+            'title' => 'Apple ticket',
+            'organization' => $organization,
+            'status' => 'closed',
+        ]);
+        Factory\TicketFactory::createOne([
+            'title' => 'Banana ticket',
+            'organization' => $organization,
+            'status' => 'closed',
+        ]);
+        Factory\TicketFactory::createOne([
+            'title' => 'Cherry ticket',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/tickets.csv?q=status%3Aclosed&sort=title-asc');
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Apple ticket', $content);
+        $this->assertStringContainsString('Banana ticket', $content);
+        $this->assertStringNotContainsString('Cherry ticket', $content);
+        $this->assertLessThan(strpos($content, 'Banana ticket'), strpos($content, 'Apple ticket'));
+    }
+
+    public function testGetCsvAppliesView(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization->_real());
+        Factory\TicketFactory::createOne([
+            'title' => 'Ticket owned by me',
+            'organization' => $organization,
+            'requester' => $user,
+            'status' => 'new',
+        ]);
+        Factory\TicketFactory::createOne([
+            'title' => 'Ticket owned by other',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/tickets.csv?view=owned');
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Ticket owned by me', $content);
+        $this->assertStringNotContainsString('Ticket owned by other', $content);
+    }
+
+    public function testGetCsvUsesUserLocale(): void
+    {
+        $client = static::createClient();
+        $user = Factory\UserFactory::createOne(['locale' => 'fr_FR']);
+        $client->loginUser($user->_real());
+        $organization = Factory\OrganizationFactory::createOne();
+        $this->grantOrga($user->_real(), ['orga:see', 'orga:see:tickets:all'], $organization->_real());
+        Factory\TicketFactory::createOne([
+            'title' => 'My ticket',
+            'organization' => $organization,
+            'status' => 'new',
+        ]);
+        $session = $this->getSession($client);
+        $session->set('_locale', 'fr_FR');
+        $session->save();
+
+        $client->request(Request::METHOD_GET, '/tickets.csv');
+        $content = $client->getInternalResponse()->getContent();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Référence', $content);
+        $this->assertStringContainsString('Créé le', $content);
+        $this->assertStringNotContainsString('Reference', $content);
+        $this->assertStringNotContainsString('Created at', $content);
+    }
+
+    public function testGetCsvRedirectsToLoginIfNotConnected(): void
+    {
+        $client = static::createClient();
+
+        $client->request(Request::METHOD_GET, '/tickets.csv');
+
+        $this->assertResponseRedirects('/login', 302);
+    }
+
     public function testGetNewRendersCorrectly(): void
     {
         $client = static::createClient();

--- a/tests/Service/TicketCsvExporterTest.php
+++ b/tests/Service/TicketCsvExporterTest.php
@@ -1,0 +1,222 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2026 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Tests\Service;
+
+use App\Service;
+use App\Tests;
+use App\Tests\Factory;
+use PHPUnit\Framework\Attributes\Before;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class TicketCsvExporterTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+    use Tests\AuthorizationHelper;
+
+    private KernelBrowser $client;
+    private Service\TicketCsvExporter $ticketCsvExporter;
+
+    #[Before]
+    public function setupTest(): void
+    {
+        $this->client = static::createClient();
+        $container = static::getContainer();
+
+        /** @var Service\TicketCsvExporter */
+        $ticketCsvExporter = $container->get(Service\TicketCsvExporter::class);
+        $this->ticketCsvExporter = $ticketCsvExporter;
+    }
+
+    public function testStreamWritesEnglishHeader(): void
+    {
+        $content = $this->renderCsv([], 'en_GB');
+
+        $this->assertStringContainsString('ID', $content);
+        $this->assertStringContainsString('Reference', $content);
+        $this->assertStringContainsString('Created at', $content);
+        $this->assertStringContainsString('Created by', $content);
+        $this->assertStringContainsString('Time spent (minutes)', $content);
+        $this->assertStringContainsString('Labels', $content);
+    }
+
+    public function testStreamFormatsDatesAsYmdHi(): void
+    {
+        $ticket = Factory\TicketFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2026-01-15 10:30:45'),
+        ])->_real();
+
+        $content = $this->renderCsv([$ticket], 'en_GB');
+
+        $this->assertStringContainsString('2026-01-15 10:30', $content);
+        $this->assertStringNotContainsString('10:30:45', $content);
+    }
+
+    public function testStreamSumsTimeSpent(): void
+    {
+        $user = Factory\UserFactory::createOne()->_real();
+        $this->client->loginUser($user);
+        $organization = Factory\OrganizationFactory::createOne()->_real();
+        $this->grantOrga($user, [
+            'orga:see',
+            'orga:see:tickets:contracts',
+            'orga:see:tickets:time_spent:real',
+            'orga:see:tickets:time_spent:accounted',
+        ], $organization);
+        $ticket = Factory\TicketFactory::createOne([
+            'organization' => $organization,
+        ])->_real();
+        $contract = Factory\ContractFactory::createOne([
+            'organization' => $organization,
+        ])->_real();
+        Factory\TimeSpentFactory::createOne([
+            'ticket' => $ticket,
+            'contract' => $contract,
+            'time' => 30,
+            'realTime' => 30,
+        ]);
+        Factory\TimeSpentFactory::createOne([
+            'ticket' => $ticket,
+            'contract' => $contract,
+            'time' => 30,
+            'realTime' => 30,
+        ]);
+        Factory\TimeSpentFactory::createOne([
+            'ticket' => $ticket,
+            'contract' => null,
+            'time' => 30,
+            'realTime' => 30,
+        ]);
+
+        $content = $this->renderCsv([$ticket], 'en_GB');
+
+        $rows = $this->parseCsv($content);
+        $this->assertSame('90', $rows[1][19]);
+        $this->assertSame('60', $rows[1][20]);
+        $this->assertSame('30', $rows[1][21]);
+    }
+
+    public function testStreamJoinsObserversLabelsAndContractsByNewline(): void
+    {
+        $user = Factory\UserFactory::createOne()->_real();
+        $this->client->loginUser($user);
+        $organization = Factory\OrganizationFactory::createOne()->_real();
+        $this->grantOrga($user, [
+            'orga:see',
+            'orga:see:tickets:contracts',
+        ], $organization);
+        $observer1 = Factory\UserFactory::createOne(['email' => 'obs1@example.com'])->_real();
+        $observer2 = Factory\UserFactory::createOne(['email' => 'obs2@example.com'])->_real();
+        $observer3 = Factory\UserFactory::createOne(['email' => 'obs3@example.com'])->_real();
+        $label1 = Factory\LabelFactory::createOne(['name' => 'label-alpha'])->_real();
+        $label2 = Factory\LabelFactory::createOne(['name' => 'label-beta'])->_real();
+        $contract1 = Factory\ContractFactory::createOne([
+            'name' => 'contract-alpha',
+            'organization' => $organization,
+        ])->_real();
+        $contract2 = Factory\ContractFactory::createOne([
+            'name' => 'contract-beta',
+            'organization' => $organization,
+        ])->_real();
+        $ticket = Factory\TicketFactory::createOne([
+            'organization' => $organization,
+            'observers' => [$observer1, $observer2, $observer3],
+            'labels' => [$label1, $label2],
+            'contracts' => [$contract1, $contract2],
+        ])->_real();
+
+        $content = $this->renderCsv([$ticket], 'en_GB');
+
+        $rows = $this->parseCsv($content);
+        $this->assertSame("obs1@example.com\nobs2@example.com\nobs3@example.com", $rows[1][15]);
+        $this->assertSame("contract-alpha\ncontract-beta", $rows[1][18]);
+        $this->assertSame("label-alpha\nlabel-beta", $rows[1][22]);
+    }
+
+    public function testStreamRendersSolutionYesNo(): void
+    {
+        $organization = Factory\OrganizationFactory::createOne()->_real();
+        $ticketWithSolution = Factory\TicketFactory::createOne([
+            'organization' => $organization,
+        ])->_real();
+        $solution = Factory\MessageFactory::createOne([
+            'ticket' => $ticketWithSolution,
+        ])->_real();
+        $ticketWithSolution->setSolution($solution);
+        $ticketWithoutSolution = Factory\TicketFactory::createOne([
+            'organization' => $organization,
+        ])->_real();
+
+        $content = $this->renderCsv([$ticketWithSolution, $ticketWithoutSolution], 'en_GB');
+
+        $rows = $this->parseCsv($content);
+        $this->assertSame('Yes', $rows[1][17]);
+        $this->assertSame('No', $rows[2][17]);
+    }
+
+    public function testStreamLeavesPermissionedColumnsEmpty(): void
+    {
+        $user = Factory\UserFactory::createOne()->_real();
+        $this->client->loginUser($user);
+        $organization = Factory\OrganizationFactory::createOne()->_real();
+        $this->grantOrga($user, ['orga:see'], $organization);
+        $contract = Factory\ContractFactory::createOne(['organization' => $organization])->_real();
+        $ticket = Factory\TicketFactory::createOne([
+            'title' => 'My ticket',
+            'organization' => $organization,
+            'contracts' => [$contract],
+        ])->_real();
+        Factory\TimeSpentFactory::createOne([
+            'ticket' => $ticket,
+            'time' => 30,
+            'realTime' => 30,
+        ]);
+
+        $content = $this->renderCsv([$ticket], 'en_GB');
+
+        $rows = $this->parseCsv($content);
+        $this->assertSame('My ticket', $rows[1][8]);
+        $this->assertSame('', $rows[1][18]);
+        $this->assertSame('', $rows[1][19]);
+        $this->assertSame('', $rows[1][20]);
+        $this->assertSame('', $rows[1][21]);
+    }
+
+    /**
+     * @param iterable<\App\Entity\Ticket> $tickets
+     */
+    private function renderCsv(iterable $tickets, string $locale): string
+    {
+        $callback = $this->ticketCsvExporter->stream($tickets, $locale);
+        ob_start();
+        $callback();
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function parseCsv(string $content): array
+    {
+        $stream = fopen('php://memory', 'r+');
+        if ($stream === false) {
+            return [];
+        }
+        fwrite($stream, $content);
+        rewind($stream);
+        $rows = [];
+        while (($row = fgetcsv($stream, escape: '')) !== false) {
+            /** @var array<int, string> $row */
+            $rows[] = $row;
+        }
+        fclose($stream);
+        return $rows;
+    }
+}

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -513,6 +513,32 @@ tickets.events.title: '<strong>{username}</strong> renamed the ticket from “<i
 tickets.events.type.to_incident: '<strong>{username}</strong> changed the ticket to incident'
 tickets.events.type.to_request: '<strong>{username}</strong> changed the ticket to request'
 tickets.events.urgency: '<strong>{username}</strong> changed the urgency from <i>{oldValue}</i> to <i>{newValue}</i>'
+tickets.export.column.assignee: Assignee
+tickets.export.column.contracts: Contracts
+tickets.export.column.created_at: 'Created at'
+tickets.export.column.created_by: 'Created by'
+tickets.export.column.id: ID
+tickets.export.column.impact: Impact
+tickets.export.column.labels: Labels
+tickets.export.column.observers: Observers
+tickets.export.column.organization: Organization
+tickets.export.column.priority: Priority
+tickets.export.column.requester: Requester
+tickets.export.column.solution: Solution
+tickets.export.column.status: Status
+tickets.export.column.team: 'Team in charge'
+tickets.export.column.time_spent.accounted: 'Accounted time spent (minutes)'
+tickets.export.column.time_spent.real: 'Time spent (minutes)'
+tickets.export.column.time_spent.unaccounted: 'Unaccounted time spent (minutes)'
+tickets.export.column.title: Title
+tickets.export.column.type: Type
+tickets.export.column.uid: Reference
+tickets.export.column.updated_at: 'Updated at'
+tickets.export.column.updated_by: 'Updated by'
+tickets.export.column.urgency: Urgency
+tickets.export.csv: 'Export as CSV'
+tickets.export.solution.no: 'No'
+tickets.export.solution.yes: 'Yes'
 tickets.filters.actors.title: 'Filter by actors'
 tickets.filters.assignee.no: 'Unassigned only'
 tickets.filters.labels.title: 'Filter by labels'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -513,6 +513,32 @@ tickets.events.title: "<strong>{username}</strong> a renommé le ticket de «\_<
 tickets.events.type.to_incident: '<strong>{username}</strong> a changé le ticket en incident'
 tickets.events.type.to_request: '<strong>{username}</strong> a changé le ticket en demande'
 tickets.events.urgency: '<strong>{username}</strong> a changé l’urgence de <i>{oldValue}</i> à <i>{newValue}</i>'
+tickets.export.column.assignee: 'Attribué à'
+tickets.export.column.contracts: Contrats
+tickets.export.column.created_at: 'Créé le'
+tickets.export.column.created_by: 'Créé par'
+tickets.export.column.id: ID
+tickets.export.column.impact: Impact
+tickets.export.column.labels: Étiquettes
+tickets.export.column.observers: Observateurs
+tickets.export.column.organization: Organisation
+tickets.export.column.priority: Priorité
+tickets.export.column.requester: Demandeur
+tickets.export.column.solution: Solution
+tickets.export.column.status: Statut
+tickets.export.column.team: 'Équipe responsable'
+tickets.export.column.time_spent.accounted: 'Temps passé comptabilisé (minutes)'
+tickets.export.column.time_spent.real: 'Temps passé (minutes)'
+tickets.export.column.time_spent.unaccounted: 'Temps passé non comptabilisé (minutes)'
+tickets.export.column.title: Titre
+tickets.export.column.type: Type
+tickets.export.column.uid: Référence
+tickets.export.column.updated_at: 'Mis à jour le'
+tickets.export.column.updated_by: 'Mis à jour par'
+tickets.export.column.urgency: Urgence
+tickets.export.csv: 'Exporter en CSV'
+tickets.export.solution.no: Non
+tickets.export.solution.yes: Oui
 tickets.filters.actors.title: 'Filtrer par acteurs'
 tickets.filters.assignee.no: 'Non attribués seulement'
 tickets.filters.labels.title: 'Filtrer par étiquettes'


### PR DESCRIPTION
## Related issue(s)

Closes #883.

## How to test manually

1. Log in as an agent with access to at least one organization.
2. Go to /tickets. A discreet "Export as CSV" button appears next to the sort button.
3. Click it. A file named bileto-tickets-YYYY-MM-DD.csv is downloaded.
4. Open the file in LibreOffice Calc or Excel. The 23 columns should appear, the BOM UTF-8 should preserve accents, and enum values (type, status, urgency, impact, priority, solution) should be translated in your locale language.
5. Add a query and a sort to the URL, for example /tickets?q=status:open&sort=created-asc, click the button again. The CSV should reflect the current filter and order.
6. Repeat on /organizations/{uid}/tickets. The downloaded filename should contain the organization UID.
7. Log in with another user without the orga:see:tickets:contracts or orga:see:tickets:time_spent permissions on the ticket's organization. The corresponding columns should be empty in the exported CSV.
8. Switch the user's locale (Profile → Preferences) between English and French. The CSV headers and translated values should follow the user's locale.

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn't applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->
- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved