### PR TITLE
fix: Don't display "optional" in button labels

### DIFF
--- a/templates/form/bileto_theme.html.twig
+++ b/templates/form/bileto_theme.html.twig
@@ -126,23 +126,25 @@
     {%- set required = required|default(false) -%}
     {%- set no_optional = no_optional|default(false) -%}
 
-    {%- if disabled %}
-        <small class="text--secondary">
-            {{ 'forms.read_only' | trans }}
-        </small>
-    {%- elseif not no_optional %}
-        {%- if not required and attr.maxlength is defined -%}
+    {%- if 'button' not in form.vars.block_prefixes -%}
+        {%- if disabled %}
             <small class="text--secondary">
-                {{ 'forms.optional_max_chars' | trans({ number: attr.maxlength }) }}
+                {{ 'forms.read_only' | trans }}
             </small>
-        {%- elseif not required -%}
-            <small class="text--secondary">
-                {{ 'forms.optional' | trans }}
-            </small>
-        {%- elseif attr.maxlength is defined -%}
-            <small class="text--secondary">
-                {{ 'forms.max_chars' | trans({ number: attr.maxlength }) }}
-            </small>
+        {%- elseif not no_optional %}
+            {%- if not required and attr.maxlength is defined -%}
+                <small class="text--secondary">
+                    {{ 'forms.optional_max_chars' | trans({ number: attr.maxlength }) }}
+                </small>
+            {%- elseif not required -%}
+                <small class="text--secondary">
+                    {{ 'forms.optional' | trans }}
+                </small>
+            {%- elseif attr.maxlength is defined -%}
+                <small class="text--secondary">
+                    {{ 'forms.max_chars' | trans({ number: attr.maxlength }) }}
+                </small>
+            {%- endif %}
         {%- endif %}
     {%- endif %}
 {%- endblock -%}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Go to  the preferences form (or any other form)
2. Verify that "(optional)" is not present in the submit button

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
