### PR TITLE
feat: Make the quick search submit button sticky

### DIFF
--- a/assets/stylesheets/components/forms.css
+++ b/assets/stylesheets/components/forms.css
@@ -344,6 +344,25 @@ legend {
     text-align: center;
 }
 
+.form__actions-search {
+    position: sticky;
+    bottom: 0;
+
+    padding: var(--space-smaller);
+
+    text-align: right;
+
+    background-color: var(--color-grey3);
+    border-radius: var(--border-radius);
+}
+
+@media (min-width: 800px) {
+    .form__actions-search {
+        margin-right: calc(-1 * var(--space-small));
+        margin-left: calc(-1 * var(--space-small));
+    }
+}
+
 .input-container {
     --button-size: 2.5rem;
 

--- a/src/Form/Ticket/QuickSearchForm.php
+++ b/src/Form/Ticket/QuickSearchForm.php
@@ -176,7 +176,7 @@ class QuickSearchForm extends AbstractType
                 'class' => 'button',
             ],
             'row_attr' => [
-                'class' => 'text--right',
+                'class' => 'form__actions-search',
             ],
         ]);
 


### PR DESCRIPTION
## Related issue(s)

The button wasn't visible most of the time, making it hard to discover, and easily forgetable.

Making it sticky on the bottom of the screen brings it to the attention of the user.

Closes https://github.com/Probesys/bileto/issues/1042

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Go to the list of tickets
2. Verify in the "Quick search" form that the submit button is always visible

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
