### PR TITLE
fix: Prevent Bileto to fall in a notification infinite loop

### DIFF
--- a/docs/developers/email-collector.md
+++ b/docs/developers/email-collector.md
@@ -24,6 +24,7 @@ This is the job of the [`CreateTicketsFromMailboxEmailsHandler`](/src/MessageHan
 
 For each `MailboxEmail`:
 
+0. it ignores autoreply emails, emails sent by Bileto itself, or emails already processed;
 1. it gets the requester (i.e. the `From` header);
 2. it gets the default organization of the requester;
 3. it detects a potential ticket to which the email might reply;

--- a/src/Entity/MailboxEmail.php
+++ b/src/Entity/MailboxEmail.php
@@ -12,6 +12,7 @@ use App\Repository\MailboxEmailRepository;
 use App\Service;
 use App\Uid\UidEntityInterface;
 use App\Uid\UidEntityTrait;
+use App\Utils\Email;
 use App\Utils\Time;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -131,12 +132,13 @@ class MailboxEmail implements EntityInterface, MonitorableEntityInterface, UidEn
 
     public function getMessageId(): string
     {
-        return $this->getEmail()->getMessageId()->first();
+        $messageId = $this->getEmail()->getMessageId()->first();
+        return str_replace(['<', '>'], '', $messageId);
     }
 
     public function getFrom(): string
     {
-        return $this->getEmail()->getFrom()->first()->mail;
+        return Email::normalize($this->getEmail()->getFrom()->first()->mail);
     }
 
     /**
@@ -148,7 +150,7 @@ class MailboxEmail implements EntityInterface, MonitorableEntityInterface, UidEn
         $ccAddresses = $email->getTo()->all();
 
         return array_map(function (PHPIMAP\Address $address): string {
-            return $address->mail;
+            return Email::normalize($address->mail);
         }, $ccAddresses);
     }
 
@@ -161,7 +163,7 @@ class MailboxEmail implements EntityInterface, MonitorableEntityInterface, UidEn
         $ccAddresses = $email->getCc()->all();
 
         return array_map(function (PHPIMAP\Address $address): string {
-            return $address->mail;
+            return Email::normalize($address->mail);
         }, $ccAddresses);
     }
 

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -88,10 +88,27 @@ class CreateTicketsFromMailboxEmailsHandler
             return;
         }
 
+        if ($this->isSelfEmail($mailboxEmail)) {
+            $this->logger->notice("MailboxEmail #{$mailboxEmail->getId()} ignored: detected as sent by Bileto itself");
+
+            $this->mailboxEmailRepository->remove($mailboxEmail, true);
+
+            return;
+        }
+
+        if ($this->isAlreadyProcessed($mailboxEmail)) {
+            $this->logger->notice("MailboxEmail #{$mailboxEmail->getId()} ignored: detected as already processed");
+
+            $this->mailboxEmailRepository->remove($mailboxEmail, true);
+
+            return;
+        }
+
         // First, get the user matching with the sender of the email.
         $sender = $this->getSender($mailboxEmail);
 
         if (!$sender) {
+            // Don't log or mark the mail in error as it is done by `getSender()`.
             return;
         }
 
@@ -137,6 +154,28 @@ class CreateTicketsFromMailboxEmailsHandler
         $this->mailboxEmailRepository->remove($mailboxEmail, true);
 
         $this->activeUser->change(null);
+    }
+
+    /**
+     * Return true if the mail is detected as sent by Bileto itself (based on
+     * the "From" address).
+     */
+    private function isSelfEmail(Entity\MailboxEmail $mailboxEmail): bool
+    {
+        $senderEmail = $mailboxEmail->getFrom();
+        return $senderEmail === $this->mailerFrom;
+    }
+
+    /**
+     * Return true if the mail has already been processed (or sent by Bileto
+     * based on the Message-Id).
+     */
+    private function isAlreadyProcessed(Entity\MailboxEmail $mailboxEmail): bool
+    {
+        $messageId = $mailboxEmail->getMessageId();
+        $reference = "email:{$messageId}";
+        $existingMessage = $this->messageRepository->findOneByNotificationReference($reference);
+        return $existingMessage !== null;
     }
 
     /**

--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -46,6 +46,7 @@ class CreateTicketsFromMailboxEmailsHandler
         #[Autowire(env: 'MAILER_FROM')]
         private string $mailerFrom,
     ) {
+        $this->mailerFrom = Utils\Email::normalize($this->mailerFrom);
     }
 
     public function __invoke(Message\CreateTicketsFromMailboxEmails $message): void

--- a/src/MessageHandler/SendMessageEmailHandler.php
+++ b/src/MessageHandler/SendMessageEmailHandler.php
@@ -152,8 +152,8 @@ class SendMessageEmailHandler
         // Set correct references headers so email clients can add the email to
         // the conversation thread.
         $emailReferences = [];
-        foreach ($ticket->getMessages(confidential: false) as $message) {
-            $references = $message->getEmailNotificationsReferences();
+        foreach ($ticket->getMessages(confidential: false) as $ticketMessage) {
+            $references = $ticketMessage->getEmailNotificationsReferences();
             if ($references) {
                 $emailReferences = array_merge($emailReferences, $references);
             }

--- a/src/Utils/Email.php
+++ b/src/Utils/Email.php
@@ -8,6 +8,11 @@ namespace App\Utils;
 
 class Email
 {
+    public static function normalize(string $email): string
+    {
+        return mb_strtolower(trim($email));
+    }
+
     public static function extractDomain(string $email): string
     {
         $domain = mb_strrchr($email, '@');

--- a/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
+++ b/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
@@ -760,6 +760,81 @@ class CreateTicketsFromMailboxEmailsHandlerTest extends WebTestCase
         $this->assertSame(0, MessageFactory::count());
     }
 
+    public function testInvokeIgnoresSelfEmail(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $email = $_ENV['MAILER_FROM'];
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+            'email' => $email,
+        ]);
+        // While this user SHOULD NOT have any permission, it CAN have one. We
+        // want to be sure the email is not processed even in this case.
+        $this->grantOrga($user->_real(), ['orga:create:tickets'], $organization->_real());
+        $subject = \Zenstruck\Foundry\faker()->words(3, true);
+        $body = \Zenstruck\Foundry\faker()->randomHtml();
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => $user->getEmail(),
+            'subject' => $subject,
+            'htmlBody' => $body,
+        ]);
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(0, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+    }
+
+    public function testInvokeIgnoresAlreadyProcessed(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+
+        $messageId = 'foobar@example.com';
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+        ]);
+        $ticket = TicketFactory::createOne([
+            'organization' => $organization,
+            'requester' => $user,
+        ]);
+        $message = MessageFactory::createOne([
+            'ticket' => $ticket,
+            'createdBy' => $user,
+            'notificationsReferences' => ["email:{$messageId}"],
+        ]);
+        $this->grantOrga($user->_real(), ['orga:create:tickets'], $organization->_real());
+        $subject = \Zenstruck\Foundry\faker()->words(3, true);
+        $body = \Zenstruck\Foundry\faker()->randomHtml();
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'id' => $messageId,
+            'from' => $user->getEmail(),
+            'subject' => $subject,
+            'htmlBody' => $body,
+        ]);
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(1, TicketFactory::count());
+        $this->assertSame(1, MessageFactory::count());
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(0, MailboxEmailFactory::count());
+        $this->assertSame(1, TicketFactory::count());
+        $this->assertSame(1, MessageFactory::count());
+    }
+
     public function testInvokeFailsIfRequesterDoesNotExists(): void
     {
         $container = static::getContainer();

--- a/tests/Utils/EmailTest.php
+++ b/tests/Utils/EmailTest.php
@@ -11,6 +11,15 @@ use PHPUnit\Framework\TestCase;
 
 class EmailTest extends TestCase
 {
+    public function testNormalize(): void
+    {
+        $email = "\nAlix@Example.com\t ";
+
+        $normalizedEmail = Email::normalize($email);
+
+        $this->assertEquals('alix@example.com', $normalizedEmail);
+    }
+
     public function testExtractDomain(): void
     {
         $email = 'alix@example.com';


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Send an email to an alias of the email that sends the notifications and receive the emails
2. Verify that the address is added as an observer and receive the notifications
3. Verify that the notifications are simply deleted by Bileto and not added to the ticket

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
