### PR TITLE
fix: Handle opening ticket if requester is null

### DIFF
--- a/src/Form/AnswerForm.php
+++ b/src/Form/AnswerForm.php
@@ -50,7 +50,7 @@ class AnswerForm extends AbstractType
             $currentUser = $this->security->getUser();
 
             $userIsAgent = $this->authorizer->isAgent($organization);
-            $userIsRequester = $requester->getId() === $currentUser->getId();
+            $userIsRequester = $requester?->getId() === $currentUser->getId();
             $userIsAssignee = $assignee?->getId() === $currentUser->getId();
 
             if ($userIsAgent) {

--- a/src/Twig/TicketEventChangesFormatterExtension.php
+++ b/src/Twig/TicketEventChangesFormatterExtension.php
@@ -199,8 +199,17 @@ class TicketEventChangesFormatterExtension
     private function formatRequesterChanges(?Entity\User $user, array $changes): string
     {
         $username = $this->formatUserName($user);
-        $oldRequester = $this->userRepository->find($changes[0]);
-        $oldRequesterUsername = $this->formatUserName($oldRequester);
+
+        if ($changes[0]) {
+            $oldRequester = $this->userRepository->find($changes[0]);
+            $oldRequesterUsername = $this->formatUserName($oldRequester);
+        } else {
+            // This should never happens, unless a ticket without any requester
+            // was _imported_. The case could be better handled, but it's so
+            // specific that we don't feel the need to spend more time on it.
+            $oldRequesterUsername = 'null';
+        }
+
         $newRequester = $this->userRepository->find($changes[1]);
         $newRequesterUsername = $this->formatUserName($newRequester);
 

--- a/templates/tickets/_list.html.twig
+++ b/templates/tickets/_list.html.twig
@@ -128,7 +128,7 @@
                         {{ 'tickets.requester' | trans }}
                     </span>
 
-                    {{ ticket.requester.displayName }}
+                    {{ ticket.requester?.displayName }}
                 </div>
 
                 <div class="list-tickets__assignee" title="{{ 'tickets.assignee' | trans }}">

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -209,7 +209,7 @@
                             </span>
 
                             <strong>
-                                {{ ticket.requester.displayName }}
+                                {{ ticket.requester?.displayName }}
                             </strong>
                         </p>
 
@@ -243,7 +243,7 @@
                                             data-turbo-preserve-scroll
                                         >
                                             <input type="hidden" name="ticket_actors[_token]" value="{{ csrf_token('ticket actors') }}">
-                                            <input type="hidden" name="ticket_actors[requester]" value="{{ ticket.requester.id }}">
+                                            <input type="hidden" name="ticket_actors[requester]" value="{{ ticket.requester?.id }}">
                                             <input type="hidden" name="ticket_actors[team]" value="{{ ticket.team ? ticket.team.id }}">
                                             {% for observer in ticket.observers %}
                                                 <input type="hidden" name="ticket_actors[observers][]" value="{{ observer.id }}">


### PR DESCRIPTION
## Related issue(s)

Bileto *do not* allow to set an empty requester. It is however possible to import a ticket without any requester.

There are probably other places where Bileto fails with a ticket without a requester, but now the interface can load just enough to set a requester.

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Setup a ticket
2. Set the ticket.requester_id to null in database
3. Load the page and verify that it works
4. Set a requester and verify the page still loads

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
