### PR TITLE
fix: Improve handling of email subject to ticket title

### DIFF
--- a/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
+++ b/src/MessageHandler/CreateTicketsFromMailboxEmailsHandler.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Webklex\PHPIMAP;
 
 #[AsMessageHandler]
@@ -37,12 +38,14 @@ class CreateTicketsFromMailboxEmailsHandler
         private Service\TicketAssigner $ticketAssigner,
         private Service\UserCreator $userCreator,
         private Service\UserService $userService,
+        private Service\Locales $locales,
         private ActivityMonitor\ActiveUser $activeUser,
         private HtmlSanitizerInterface $appMessageSanitizer,
         private LoggerInterface $logger,
         private UrlGeneratorInterface $urlGenerator,
         private EventDispatcherInterface $eventDispatcher,
         private LockFactory $lockFactory,
+        private TranslatorInterface $translator,
         #[Autowire(env: 'MAILER_FROM')]
         private string $mailerFrom,
     ) {
@@ -272,11 +275,22 @@ class CreateTicketsFromMailboxEmailsHandler
             return null;
         }
 
-        // Finally, build a ticket.
-        $subject = $mailboxEmail->getSubject();
+        // Get a valid title from the mail subject.
+        $title = $mailboxEmail->getSubject();
+        $title = trim($title);
 
+        if (!$title) {
+            $title = $this->translator->trans(
+                'ticket.title.missing',
+                locale: $this->locales->getDefaultLocale()
+            );
+        } elseif (mb_strlen($title) > Entity\Ticket::TITLE_MAX_LENGTH) {
+            $title = mb_substr($title, 0, Entity\Ticket::TITLE_MAX_LENGTH - 1) . '…';
+        }
+
+        // Finally, build a ticket.
         $ticket = new Entity\Ticket();
-        $ticket->setTitle($subject);
+        $ticket->setTitle($title);
         $ticket->setOrganization($defaultOrganization);
         $ticket->setRequester($sender);
 

--- a/templates/tickets/_list.html.twig
+++ b/templates/tickets/_list.html.twig
@@ -15,7 +15,11 @@
                 <div class="col--extend flow flow--small">
                     <h3 class="list-tickets__title list__item-title">
                         <a class="list-tickets__anchor" href="{{ path('ticket', {'uid': ticket.uid}) }}">
-                            {{ ticket.title }}
+                            {% if ticket.title %}
+                                {{ ticket.title }}
+                            {% else %}
+                                {{ 'ticket.title.missing' | trans }}
+                            {% endif %}
                         </a>
                     </h3>
 

--- a/templates/tickets/show.html.twig
+++ b/templates/tickets/show.html.twig
@@ -39,7 +39,12 @@
         <div class="flow flow--small text--center">
             <div class="cols cols--center text--center flow flow--small">
                 <h1>
-                    #{{ ticket.id }} {{ ticket.title }}
+                    #{{ ticket.id }}
+                    {% if ticket.title %}
+                        {{ ticket.title }}
+                    {% else %}
+                        {{ 'ticket.title.missing' | trans }}
+                    {% endif %}
                 </h1>
 
                 <span class="ticket__status badge badge--{{ ticket.statusBadgeColor }}" title="{{ 'tickets.status' | trans }}">

--- a/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
+++ b/tests/MessageHandler/CreateTicketsFromMailboxEmailsHandlerTest.php
@@ -185,6 +185,77 @@ class CreateTicketsFromMailboxEmailsHandlerTest extends WebTestCase
         $this->assertSame($team->getUid(), $assignedTeam->getUid());
     }
 
+    public function testInvokeCreatesATicketAndForcesATitle(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+        $emailDate = Time::ago(1, 'hour');
+
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+        ]);
+        $this->grantOrga($user->_real(), ['orga:create:tickets'], $organization->_real());
+        $subject = ' ';
+        $body = \Zenstruck\Foundry\faker()->randomHtml();
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => $user->getEmail(),
+            'subject' => $subject,
+            'htmlBody' => $body,
+            'date' => $emailDate,
+        ]);
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(0, MailboxEmailFactory::count());
+        $this->assertSame(1, TicketFactory::count());
+        $this->assertSame(1, MessageFactory::count());
+
+        $ticket = TicketFactory::first();
+        $this->assertSame('No title', $ticket->getTitle());
+    }
+
+    public function testInvokeCreatesATicketAndShrinksTheTitle(): void
+    {
+        $container = static::getContainer();
+        /** @var MessageBusInterface */
+        $bus = $container->get(MessageBusInterface::class);
+        $emailDate = Time::ago(1, 'hour');
+
+        $organization = OrganizationFactory::createOne();
+        $user = UserFactory::createOne([
+            'organization' => $organization,
+        ]);
+        $this->grantOrga($user->_real(), ['orga:create:tickets'], $organization->_real());
+        $subject = str_repeat('a', Entity\Ticket::TITLE_MAX_LENGTH + 1);
+        $body = \Zenstruck\Foundry\faker()->randomHtml();
+        $mailboxEmail = MailboxEmailFactory::createOne([
+            'from' => $user->getEmail(),
+            'subject' => $subject,
+            'htmlBody' => $body,
+            'date' => $emailDate,
+        ]);
+
+        $this->assertSame(1, MailboxEmailFactory::count());
+        $this->assertSame(0, TicketFactory::count());
+        $this->assertSame(0, MessageFactory::count());
+
+        $bus->dispatch(new CreateTicketsFromMailboxEmails());
+
+        $this->assertSame(0, MailboxEmailFactory::count());
+        $this->assertSame(1, TicketFactory::count());
+        $this->assertSame(1, MessageFactory::count());
+
+        $ticket = TicketFactory::first();
+        $expectedTitle = str_repeat('a', Entity\Ticket::TITLE_MAX_LENGTH - 1) . '…';
+        $this->assertSame($expectedTitle, $ticket->getTitle());
+    }
+
     public function testInvokeAnswersToTicketIfTicketIdIsGiven(): void
     {
         $container = static::getContainer();

--- a/translations/messages+intl-icu.en_GB.yaml
+++ b/translations/messages+intl-icu.en_GB.yaml
@@ -478,6 +478,7 @@ teams.show.authorizations.new: 'Give an authorization'
 teams.show.authorizations.title: Authorizations
 teams.show.edit: 'Edit the team'
 teams.show.team_responsible: 'Responsible team'
+ticket.title.missing: 'No title'
 tickets.actors: Actors
 tickets.actors.edit.no_access: 'The actors have been updated, but you no longer have access to the ticket.'
 tickets.actors.edit.title: 'Edit the actors'

--- a/translations/messages+intl-icu.fr_FR.yaml
+++ b/translations/messages+intl-icu.fr_FR.yaml
@@ -478,6 +478,7 @@ teams.show.authorizations.new: 'Donner une autorisation'
 teams.show.authorizations.title: Autorisations
 teams.show.edit: 'Modifier l’équipe'
 teams.show.team_responsible: 'Équipe responsable'
+ticket.title.missing: 'Sans titre'
 tickets.actors: Acteurs
 tickets.actors.edit.no_access: 'Les acteurs ont été mis à jour, mais vous n’avez plus accès au ticket.'
 tickets.actors.edit.title: 'Modifier les acteurs'


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Send an email to the support mailbox with no subject
2. Send another one with more than 255 characters
3. Verify both tickets are created: the first must have title "No title", the other one must be truncated and end with "…"

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
