### PR TITLE
sec: Limit unattached documents to organizations

### DIFF
--- a/migrations/Version20260903150455AddContextToMessageDocument.php
+++ b/migrations/Version20260903150455AddContextToMessageDocument.php
@@ -1,0 +1,43 @@
+<?php
+
+// This file is part of Bileto.
+// Copyright 2022-2026 Probesys
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20260903150455AddContextToMessageDocument extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add context fields to message_document table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql("ALTER TABLE message_document ADD context VARCHAR(255) DEFAULT '' NOT NULL");
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql("ALTER TABLE message_document ADD context VARCHAR(255) DEFAULT '' NOT NULL");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbPlatform = $this->connection->getDatabasePlatform();
+        if ($dbPlatform instanceof PostgreSQLPlatform) {
+            $this->addSql('ALTER TABLE message_document DROP context');
+        } elseif ($dbPlatform instanceof MariaDBPlatform) {
+            $this->addSql('ALTER TABLE message_document DROP context');
+        }
+    }
+}

--- a/src/Controller/MessageDocumentsController.php
+++ b/src/Controller/MessageDocumentsController.php
@@ -37,10 +37,10 @@ class MessageDocumentsController extends BaseController
     {
         $this->denyAccessUnlessGranted('orga:see', 'any');
 
+        $context = trim($request->query->getString('context', ''));
         $file = $request->files->get('document');
 
-        /** @var string */
-        $csrfToken = $request->request->get('_csrf_token', '');
+        $csrfToken = $request->request->getString('_csrf_token', '');
 
         if (!$this->isCsrfTokenValid('create message document', $csrfToken)) {
             return new JsonResponse([
@@ -85,6 +85,8 @@ class MessageDocumentsController extends BaseController
                 ], Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         }
+
+        $messageDocument->setContext($context);
 
         $this->messageDocumentRepository->save($messageDocument, true);
 
@@ -243,6 +245,9 @@ class MessageDocumentsController extends BaseController
             $conditions['message'] = null;
         }
 
+        $context = $request->query->get('context', '');
+        $conditions['context'] = $context;
+
         $messageDocuments = $this->messageDocumentRepository->findBy(
             $conditions,
             ['createdAt' => 'ASC'],
@@ -250,6 +255,7 @@ class MessageDocumentsController extends BaseController
 
         return $this->render('message_documents/index.html.twig', [
             'messageDocuments' => $messageDocuments,
+            'context' => $context,
         ]);
     }
 }

--- a/src/Entity/MessageDocument.php
+++ b/src/Entity/MessageDocument.php
@@ -127,6 +127,9 @@ class MessageDocument implements EntityInterface, MonitorableEntityInterface, Ui
     #[ORM\JoinColumn(onDelete: 'CASCADE')]
     private ?Message $message = null;
 
+    #[ORM\Column(length: 255, options: ['default' => ''])]
+    private string $context = '';
+
     public function getName(): ?string
     {
         return $this->name;
@@ -272,6 +275,18 @@ class MessageDocument implements EntityInterface, MonitorableEntityInterface, Ui
     public function setMessage(?Message $message): static
     {
         $this->message = $message;
+
+        return $this;
+    }
+
+    public function getContext(): string
+    {
+        return $this->context;
+    }
+
+    public function setContext(string $context): static
+    {
+        $this->context = $context;
 
         return $this;
     }

--- a/src/Form/AnswerForm.php
+++ b/src/Form/AnswerForm.php
@@ -124,6 +124,9 @@ class AnswerForm extends AbstractType
                 'trim' => true,
                 'sanitize_html' => true,
                 'sanitizer' => 'app.message_sanitizer',
+                'attr' => [
+                    'data-context' => "ticket-{$ticket->getUid()}",
+                ],
                 'block_prefix' => 'editor',
             ]);
 

--- a/src/Form/MessageTemplateForm.php
+++ b/src/Form/MessageTemplateForm.php
@@ -44,6 +44,9 @@ class MessageTemplateForm extends AbstractType
             'trim' => true,
             'sanitize_html' => true,
             'sanitizer' => 'app.message_sanitizer',
+            'attr' => [
+                'data-context' => 'template',
+            ],
             'block_prefix' => 'editor',
         ]);
 

--- a/src/Form/TicketForm.php
+++ b/src/Form/TicketForm.php
@@ -152,6 +152,9 @@ class TicketForm extends AbstractType
                 'trim' => true,
                 'sanitize_html' => true,
                 'sanitizer' => 'app.message_sanitizer',
+                'attr' => [
+                    'data-context' => "organization-{$organization->getUid()}",
+                ],
                 'block_prefix' => 'editor',
                 'constraints' => [
                     new Assert\NotBlank(

--- a/src/TicketActivity/MessageDocumentsSubscriber.php
+++ b/src/TicketActivity/MessageDocumentsSubscriber.php
@@ -29,10 +29,29 @@ class MessageDocumentsSubscriber implements EventSubscriberInterface
     public function attachMessageDocuments(MessageEvent $event): void
     {
         $message = $event->getMessage();
+        $ticket = $message->getTicket();
+
+        // We consider a ticket to be new if it and the message were both
+        // created within the same time window (arbitrarily set to 2 seconds
+        // which should be way enough).
+        $ticketCreatedAt = $ticket->getCreatedAt()->getTimestamp();
+        $messageCreatedAt = $message->getCreatedAt()->getTimestamp();
+        $isNewTicket = abs($ticketCreatedAt - $messageCreatedAt) <= 2;
+
+        $context = "ticket-{$ticket->getUid()}";
+
+        if ($isNewTicket) {
+            // The ticket has just been created: we must use the context of the
+            // organization as the ticket UID wasn't known when uploading the
+            // files.
+            $organization = $ticket->getOrganization();
+            $context = "organization-{$organization->getUid()}";
+        }
 
         // Fetch all the unattached message documents of the author of the message.
         $messageDocuments = $this->messageDocumentRepository->findBy([
             'createdBy' => $message->getCreatedBy(),
+            'context' => $context,
             'message' => null,
         ]);
 

--- a/templates/form/bileto_theme.html.twig
+++ b/templates/form/bileto_theme.html.twig
@@ -198,7 +198,7 @@
             'required': false,
             'attr': {
                 'data-controller': 'tinymce',
-                'data-tinymce-upload-url-value': path('create message document'),
+                'data-tinymce-upload-url-value': path('create message document', { context: form.vars.attr['data-context'] | default('') }),
                 'data-tinymce-upload-csrf-value': csrf_token('create message document'),
                 'data-editor-target': 'tinymce',
                 'data-action': 'new-document->editor#newDocument remove-document->tinymce#removeImage',
@@ -208,7 +208,7 @@
         <div class="editor__documents">
             <turbo-frame
                 id="message-documents"
-                src="{{ path('message documents', { filter: 'unattached' }) }}"
+                src="{{ path('message documents', { filter: 'unattached', context: form.vars.attr['data-context'] | default('') }) }}"
                 data-controller="message-documents"
                 data-editor-target="messageDocuments"
                 data-action="remove-document->editor#removeDocument new-document->message-documents#reload"

--- a/templates/message_documents/index.html.twig
+++ b/templates/message_documents/index.html.twig
@@ -30,7 +30,7 @@
                     hidden
                     data-message-documents-target="filesSelector"
                     data-action="message-documents#uploadFiles"
-                    data-upload-url="{{ path('create message document') }}"
+                    data-upload-url="{{ path('create message document', { context: context }) }}"
                     data-upload-csrf="{{ csrf_token('create message document') }}"
                 />
             </div>

--- a/tests/Controller/MessageDocumentsControllerTest.php
+++ b/tests/Controller/MessageDocumentsControllerTest.php
@@ -449,6 +449,36 @@ class MessageDocumentsControllerTest extends WebTestCase
         );
     }
 
+    public function testGetIndexFiltersOnContext(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user->_real());
+        $message = MessageFactory::createOne();
+        $messageDocument1 = MessageDocumentFactory::createOne([
+            'createdAt' => Time::ago(2, 'hour'),
+            'createdBy' => $user->_real(),
+            'name' => 'foo.txt',
+            'message' => $message,
+            'context' => 'foo',
+        ]);
+        $messageDocument2 = MessageDocumentFactory::createOne([
+            'createdAt' => Time::ago(1, 'hour'),
+            'createdBy' => $user->_real(),
+            'name' => 'bar.txt',
+            'message' => null,
+            'context' => 'bar',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/messages/documents?context=bar');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains(
+            '[data-target="document-item"]:nth-child(1) [data-target="document-name"]',
+            'bar.txt'
+        );
+    }
+
     public function testGetIndexCanFilterUnattachedDocuments(): void
     {
         $client = static::createClient();

--- a/tests/Controller/Organizations/TicketsControllerTest.php
+++ b/tests/Controller/Organizations/TicketsControllerTest.php
@@ -471,6 +471,7 @@ class TicketsControllerTest extends WebTestCase
         list($messageDocument1, $messageDocument2) = Factory\MessageDocumentFactory::createMany(2, [
             'createdBy' => $user->_real(),
             'message' => null,
+            'context' => "organization-{$organization->getUid()}",
         ]);
 
         $client->request(Request::METHOD_POST, "/organizations/{$organization->getUid()}/tickets/new", [

--- a/tests/Controller/Tickets/MessagesControllerTest.php
+++ b/tests/Controller/Tickets/MessagesControllerTest.php
@@ -224,6 +224,7 @@ class MessagesControllerTest extends WebTestCase
         list($messageDocument1, $messageDocument2) = Factory\MessageDocumentFactory::createMany(2, [
             'createdBy' => $user->_real(),
             'message' => null,
+            'context' => "ticket-{$ticket->getUid()}",
         ]);
 
         $client->request(Request::METHOD_POST, "/tickets/{$ticket->getUid()}/messages/new", [


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

When a user uploaded a file as a MessageDocument, it was first marked as "unattached", waiting to be attached to the next message to be posted.

If a user uploaded a file while creating a ticket or answering to one, then changed of ticket before submitting the form, the uploaded file was still in the form of the other organization. While the file is visible, a distracted user could just miss it and complete the form without removing it. This could lead to leak sensitive file from a customer to another.

This change marks the unattached MessageDocuments in a certain context. The context is either the current organization (new ticket) or the current ticket (new answer), so the uploaded document is always marked for a single form.

Then, the MessageDocumentsSubscriber calculates the correct context depending on if the ticket was created right now (so it must use the organization context) or if it was already existing (using the ticket context then).

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Start a new ticket and upload a file but don't submit the form
4. Start an answer in an existing ticket of the same organization and submit
3. Verify that the file doesn't appear
2. Start another ticket in another organization and submit
5. Verify that the file doesn't appear either
6. Submit the form of the "new ticket" in the first organization
7. Verify that the file appears

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -- Get help: https://github.com/Probesys/bileto/blob/main/docs/developers/review.md
  -->

- [x] Code is manually tested
- [x] Permissions / authorizations are verified
- [x] New data can be imported
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
